### PR TITLE
Add paddle movement controls

### DIFF
--- a/lib/game_screen.dart
+++ b/lib/game_screen.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+class GameScreen extends StatefulWidget {
+  const GameScreen({super.key});
+
+  @override
+  State<GameScreen> createState() => _GameScreenState();
+}
+
+class _GameScreenState extends State<GameScreen> {
+  late Timer _timer;
+  Timer? _leftTimer;
+  Timer? _rightTimer;
+
+  double _ballX = 0.5; // fractional position across the width
+  double _ballY = 0.9; // fractional position down the screen
+  double _dx = 0.01;
+  final double _dy = -0.01; // move upward slightly
+
+  double _paddleX = 0.5; // fractional position of paddle across width
+  final double _paddleSpeed = 0.02;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(const Duration(milliseconds: 16), _updateBall);
+  }
+
+  void _startMovingLeft() {
+    _leftTimer?.cancel();
+    _leftTimer = Timer.periodic(const Duration(milliseconds: 16), (_) {
+      setState(() {
+        _paddleX = (_paddleX - _paddleSpeed).clamp(0.0, 1.0);
+      });
+    });
+  }
+
+  void _stopMovingLeft() {
+    _leftTimer?.cancel();
+    _leftTimer = null;
+  }
+
+  void _startMovingRight() {
+    _rightTimer?.cancel();
+    _rightTimer = Timer.periodic(const Duration(milliseconds: 16), (_) {
+      setState(() {
+        _paddleX = (_paddleX + _paddleSpeed).clamp(0.0, 1.0);
+      });
+    });
+  }
+
+  void _stopMovingRight() {
+    _rightTimer?.cancel();
+    _rightTimer = null;
+  }
+
+  void _updateBall(Timer timer) {
+    setState(() {
+      _ballX += _dx;
+      _ballY += _dy;
+      if (_ballX <= 0 || _ballX >= 1) {
+        _dx = -_dx;
+        _ballX = _ballX.clamp(0.0, 1.0);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    _leftTimer?.cancel();
+    _rightTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Stack(
+        children: [
+          Align(
+            alignment: Alignment(2 * _paddleX - 1, 1),
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 48.0),
+              child: Image.asset('assets/images/paddle.png'),
+            ),
+          ),
+          Align(
+            alignment: Alignment(2 * _ballX - 1, 2 * _ballY - 1),
+            child: Image.asset('assets/images/ball.png'),
+          ),
+          Align(
+            alignment: Alignment.bottomLeft,
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: _buildMoveButton(
+                icon: Icons.arrow_left,
+                onStart: _startMovingLeft,
+                onStop: _stopMovingLeft,
+              ),
+            ),
+          ),
+          Align(
+            alignment: Alignment.bottomRight,
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: _buildMoveButton(
+                icon: Icons.arrow_right,
+                onStart: _startMovingRight,
+                onStop: _stopMovingRight,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMoveButton({
+    required IconData icon,
+    required VoidCallback onStart,
+    required VoidCallback onStop,
+  }) {
+    return GestureDetector(
+      onTapDown: (_) => onStart(),
+      onTapUp: (_) => onStop(),
+      onTapCancel: onStop,
+      child: Container(
+        width: 48,
+        height: 48,
+        decoration: const BoxDecoration(
+          shape: BoxShape.circle,
+          color: Colors.white24,
+        ),
+        child: Icon(icon, color: Colors.white),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,125 +1,40 @@
 import 'package:flutter/material.dart';
+import 'game_screen.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const CyberBrickSmasherApp());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class CyberBrickSmasherApp extends StatelessWidget {
+  const CyberBrickSmasherApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      title: 'Cyber Brick Smasher',
+      theme: ThemeData(useMaterial3: true),
+      home: const StartScreen(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
+class StartScreen extends StatelessWidget {
+  const StartScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
     return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
+      appBar: AppBar(title: const Text('Cyber Brick Smasher')),
       body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
+        child: ElevatedButton(
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const GameScreen()),
+            );
+          },
+          child: const Text('Start Game'),
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,10 +57,10 @@ flutter:
   # the material Icons class.
   uses-material-design: true
 
+  assets:
+    - assets/images/
+
   # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/to/resolution-aware-images

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,12 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_cyber_brick_smasher/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('Start screen shows Start Game button', (tester) async {
+    await tester.pumpWidget(const CyberBrickSmasherApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Start Game'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add continuous paddle movement buttons at the screen corners of `GameScreen`
- keep the paddle within the screen bounds while moving

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68751dc3f3b4832595d36970502a86e8