### PR TITLE
Cancel timers on dispose

### DIFF
--- a/lib/game_screen.dart
+++ b/lib/game_screen.dart
@@ -331,6 +331,10 @@ class _GameScreenState extends State<GameScreen> {
     _leftTimer?.cancel();
     _rightTimer?.cancel();
     _gunFireTimer?.cancel();
+    for (final timer in _timers.values) {
+      timer.cancel();
+    }
+    _timers.clear();
     _focusNode.dispose();
     super.dispose();
   }


### PR DESCRIPTION
## Summary
- clean up power-up timers when `_GameScreenState` is disposed

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68754ad335c08325a3ee04e0bfb81da6