### PR TITLE
Add level completion dialog

### DIFF
--- a/lib/game_screen.dart
+++ b/lib/game_screen.dart
@@ -1,0 +1,496 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class GameScreen extends StatefulWidget {
+  const GameScreen({super.key});
+
+  @override
+  State<GameScreen> createState() => _GameScreenState();
+}
+
+enum PowerUpType { fireball, magnet, multiball, phaseball, gun }
+
+String _powerUpImage(PowerUpType type) {
+  switch (type) {
+    case PowerUpType.fireball:
+      return 'assets/images/powerup_fireball.png';
+    case PowerUpType.magnet:
+      return 'assets/images/powerup_magnet.png';
+    case PowerUpType.multiball:
+      return 'assets/images/powerup_multiball.png';
+    case PowerUpType.phaseball:
+      return 'assets/images/powerup_phaseball.png';
+    case PowerUpType.gun:
+      return 'assets/images/powerup_gun.png';
+  }
+}
+
+class _FallingPowerUp {
+  _FallingPowerUp({required this.type, required this.position});
+  PowerUpType type;
+  Offset position;
+}
+
+class _Block {
+  _Block(this.rect, {this.unbreakable = false});
+  Rect rect;
+  final bool unbreakable;
+}
+
+class _GameScreenState extends State<GameScreen> {
+  late Timer _timer;
+  Timer? _leftTimer;
+  Timer? _rightTimer;
+  late FocusNode _focusNode;
+
+  double _ballX = 0.5; // fractional position across the width
+  double _ballY = 0.9; // fractional position down the screen
+  double _dx = 0.01;
+  double _dy = -0.01; // moving direction vertically
+
+  double _paddleX = 0.5; // fractional position of paddle across width
+  final double _paddleSpeed = 0.02;
+
+  final List<_Block> _blocks = [];
+  int _score = 0;
+  final List<_FallingPowerUp> _powerUps = [];
+  final Set<PowerUpType> _activePowerUps = {};
+  final Map<PowerUpType, Timer> _timers = {};
+  final double _powerUpSpeed = 0.01;
+  final List<Offset> _projectiles = [];
+  Timer? _gunFireTimer;
+  final double _projectileSpeed = 0.02;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = FocusNode();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _focusNode.requestFocus();
+    });
+    _createBlocks();
+    _timer = Timer.periodic(const Duration(milliseconds: 16), _updateBall);
+  }
+
+  void _startMovingLeft() {
+    _leftTimer?.cancel();
+    _leftTimer = Timer.periodic(const Duration(milliseconds: 16), (_) {
+      setState(() {
+        _paddleX = (_paddleX - _paddleSpeed).clamp(0.0, 1.0);
+      });
+    });
+  }
+
+  void _stopMovingLeft() {
+    _leftTimer?.cancel();
+    _leftTimer = null;
+  }
+
+  void _startMovingRight() {
+    _rightTimer?.cancel();
+    _rightTimer = Timer.periodic(const Duration(milliseconds: 16), (_) {
+      setState(() {
+        _paddleX = (_paddleX + _paddleSpeed).clamp(0.0, 1.0);
+      });
+    });
+  }
+
+  void _stopMovingRight() {
+    _rightTimer?.cancel();
+    _rightTimer = null;
+  }
+
+  void _handleKeyEvent(RawKeyEvent event) {
+    if (event is RawKeyDownEvent) {
+      if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+        if (_leftTimer == null) _startMovingLeft();
+      } else if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+        if (_rightTimer == null) _startMovingRight();
+      }
+    } else if (event is RawKeyUpEvent) {
+      if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+        _stopMovingLeft();
+      } else if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+        _stopMovingRight();
+      }
+    }
+  }
+
+  void _createBlocks() {
+    const int rows = 4;
+    const int cols = 6;
+    const double spacing = 0.02;
+    const double topOffset = 0.1;
+    const double blockHeight = 0.05;
+    final double blockWidth = (1 - (cols + 1) * spacing) / cols;
+    for (int r = 0; r < rows; r++) {
+      for (int c = 0; c < cols; c++) {
+        final double x = spacing + c * (blockWidth + spacing);
+        final double y = topOffset + r * (blockHeight + spacing);
+        final bool unbreakable = r == 0; // first row is unbreakable
+        _blocks.add(_Block(
+          Rect.fromLTWH(x, y, blockWidth, blockHeight),
+          unbreakable: unbreakable,
+        ));
+      }
+    }
+  }
+
+  void _updateBall(Timer timer) {
+    setState(() {
+      _ballX += _dx;
+      _ballY += _dy;
+      if (_ballX <= 0 || _ballX >= 1) {
+        _dx = -_dx;
+        _ballX = _ballX.clamp(0.0, 1.0);
+      }
+      if (_ballY <= 0) {
+        _dy = -_dy;
+        _ballY = _ballY.clamp(0.0, 1.0);
+      }
+
+      // simple paddle collision when moving downward
+      const double paddleY = 0.95; // approximate fractional vertical position
+      const double paddleHalfWidth = 0.1; // half the paddle width as fraction
+      if (_dy > 0 && _ballY >= paddleY &&
+          (_ballX - _paddleX).abs() <= paddleHalfWidth) {
+        _dy = -_dy;
+        _ballY = paddleY;
+      }
+
+      // check for collision with blocks
+      const double ballSize = 0.04;
+      final ballRect = Rect.fromLTWH(
+        _ballX - ballSize / 2,
+        _ballY - ballSize / 2,
+        ballSize,
+        ballSize,
+      );
+      for (int i = 0; i < _blocks.length; i++) {
+        final block = _blocks[i];
+        if (ballRect.overlaps(block.rect)) {
+          if (!block.unbreakable && !_activePowerUps.contains(PowerUpType.fireball)) {
+            final intersection = ballRect.intersect(block.rect);
+            if (intersection.height >= intersection.width) {
+              _dx = -_dx;
+              if (_dx > 0) {
+                _ballX = block.rect.left - ballSize / 2;
+              } else {
+                _ballX = block.rect.right + ballSize / 2;
+              }
+            } else {
+              _dy = -_dy;
+              if (_dy > 0) {
+                _ballY = block.rect.top - ballSize / 2;
+              } else {
+                _ballY = block.rect.bottom + ballSize / 2;
+              }
+            }
+          }
+          if (!block.unbreakable) {
+            _blocks.removeAt(i);
+            _score += 10;
+            if (Random().nextDouble() < 0.25) {
+              final types = PowerUpType.values;
+              final randomType = types[Random().nextInt(types.length)];
+              _powerUps.add(_FallingPowerUp(type: randomType, position: block.rect.center));
+            }
+            if (_isLevelComplete()) {
+              _showLevelCompleteDialog();
+            }
+          }
+          break;
+        }
+      }
+
+      // update power-ups
+      for (int i = _powerUps.length - 1; i >= 0; i--) {
+        final p = _powerUps[i];
+        final newPos = p.position.translate(0, _powerUpSpeed);
+        if (newPos.dy >= 1.0) {
+          _powerUps.removeAt(i);
+          continue;
+        }
+        if (newPos.dy >= paddleY && (newPos.dx - _paddleX).abs() <= paddleHalfWidth) {
+          _powerUps.removeAt(i);
+          _activatePowerUp(p.type);
+          continue;
+        }
+        p.position = newPos;
+      }
+
+      // update projectiles
+      for (int i = _projectiles.length - 1; i >= 0; i--) {
+        final newPos = _projectiles[i].translate(0, -_projectileSpeed);
+        bool remove = false;
+        final projRect =
+            Rect.fromLTWH(newPos.dx - 0.01, newPos.dy - 0.02, 0.02, 0.04);
+        for (int j = 0; j < _blocks.length; j++) {
+          final block = _blocks[j];
+          if (projRect.overlaps(block.rect) && !block.unbreakable) {
+            _blocks.removeAt(j);
+            _score += 10;
+            if (Random().nextDouble() < 0.25) {
+              final types = PowerUpType.values;
+              final randomType = types[Random().nextInt(types.length)];
+              _powerUps
+                  .add(_FallingPowerUp(type: randomType, position: block.rect.center));
+            }
+            if (_isLevelComplete()) {
+              _showLevelCompleteDialog();
+            }
+            remove = true;
+            break;
+          }
+        }
+        if (remove || newPos.dy <= 0) {
+          _projectiles.removeAt(i);
+        } else {
+          _projectiles[i] = newPos;
+        }
+      }
+    });
+
+    if (_ballY >= 1.0) {
+      _ballY = 1.0;
+      _timer.cancel();
+      _leftTimer?.cancel();
+      _rightTimer?.cancel();
+      _gunFireTimer?.cancel();
+      _showGameOverDialog();
+    }
+  }
+
+  void _activatePowerUp(PowerUpType type) {
+    _activePowerUps.add(type);
+    _timers[type]?.cancel();
+    _timers[type] = Timer(const Duration(seconds: 7), () {
+      setState(() {
+        _activePowerUps.remove(type);
+        if (type == PowerUpType.gun) {
+          _gunFireTimer?.cancel();
+          _gunFireTimer = null;
+        }
+      });
+    });
+    if (type == PowerUpType.gun) {
+      _gunFireTimer?.cancel();
+      _gunFireTimer =
+          Timer.periodic(const Duration(milliseconds: 500), (_) => _fireProjectile());
+    }
+    setState(() {});
+  }
+
+  void _fireProjectile() {
+    setState(() {
+      _projectiles.add(Offset(_paddleX, 0.93));
+    });
+  }
+
+  void _resetGame() {
+    _timer.cancel();
+    _leftTimer?.cancel();
+    _rightTimer?.cancel();
+    _gunFireTimer?.cancel();
+    _leftTimer = null;
+    _rightTimer = null;
+    _gunFireTimer = null;
+    setState(() {
+      _ballX = 0.5;
+      _ballY = 0.9;
+      _dx = 0.01;
+      _dy = -0.01;
+      _paddleX = 0.5;
+      _score = 0;
+      _activePowerUps.clear();
+      for (final timer in _timers.values) {
+        timer.cancel();
+      }
+      _timers.clear();
+      _blocks.clear();
+      _powerUps.clear();
+      _projectiles.clear();
+      _createBlocks();
+    });
+    _timer = Timer.periodic(const Duration(milliseconds: 16), _updateBall);
+  }
+
+  void _showGameOverDialog() {
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Game Over'),
+          content: Text('Final Score: $_score'),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                _resetGame();
+              },
+              child: const Text('Restart'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  bool _isLevelComplete() {
+    return _blocks.isNotEmpty && _blocks.every((b) => b.unbreakable);
+  }
+
+  void _showLevelCompleteDialog() {
+    _timer.cancel();
+    _leftTimer?.cancel();
+    _rightTimer?.cancel();
+    _gunFireTimer?.cancel();
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text("Level Complete!"),
+          content: Text("Score: $_score"),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                _resetGame();
+              },
+              child: const Text("Restart Level"),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    _leftTimer?.cancel();
+    _rightTimer?.cancel();
+    _gunFireTimer?.cancel();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final width = constraints.maxWidth;
+          final height = constraints.maxHeight;
+          return RawKeyboardListener(
+            focusNode: _focusNode,
+            onKey: _handleKeyEvent,
+            child: Stack(
+              children: [
+              Positioned(
+                left: 8,
+                top: 8,
+                child: Text('Score: $_score', style: const TextStyle(color: Colors.white)),
+              ),
+              for (final block in _blocks)
+                Positioned(
+                  left: block.rect.left * width,
+                  top: block.rect.top * height,
+                  width: block.rect.width * width,
+                  height: block.rect.height * height,
+                  child: Image.asset('assets/images/block_1.png'),
+                ),
+              for (final p in _powerUps)
+                Positioned(
+                  left: (p.position.dx - 0.025) * width,
+                  top: (p.position.dy - 0.025) * height,
+                  width: 0.05 * width,
+                  height: 0.05 * height,
+                  child: Image.asset(_powerUpImage(p.type)),
+                ),
+              for (final proj in _projectiles)
+                Positioned(
+                  left: (proj.dx - 0.01) * width,
+                  top: (proj.dy - 0.02) * height,
+                  width: 0.02 * width,
+                  height: 0.04 * height,
+                  child: Image.asset('assets/images/projectile.png'),
+                ),
+              Align(
+                alignment: Alignment(2 * _paddleX - 1, 1),
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: 48.0),
+                  child: Image.asset(
+                    _activePowerUps.contains(PowerUpType.gun)
+                        ? 'assets/images/paddle_with_gun.png'
+                        : 'assets/images/paddle.png',
+                  ),
+                ),
+              ),
+              Align(
+                alignment: Alignment(2 * _ballX - 1, 2 * _ballY - 1),
+                child: Image.asset(
+                  _activePowerUps.contains(PowerUpType.fireball)
+                      ? 'assets/images/ball_on_fire.png'
+                      : 'assets/images/ball.png',
+                ),
+              ),
+              Align(
+                alignment: Alignment.bottomLeft,
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: _buildMoveButton(
+                    icon: Icons.arrow_left,
+                    onStart: _startMovingLeft,
+                    onStop: _stopMovingLeft,
+                  ),
+                ),
+              ),
+              Align(
+                alignment: Alignment.bottomRight,
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: _buildMoveButton(
+                    icon: Icons.arrow_right,
+                    onStart: _startMovingRight,
+                    onStop: _stopMovingRight,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildMoveButton({
+    required IconData icon,
+    required VoidCallback onStart,
+    required VoidCallback onStop,
+  }) {
+    return GestureDetector(
+      onTapDown: (_) => onStart(),
+      onTapUp: (_) => onStop(),
+      onTapCancel: onStop,
+      child: Container(
+        width: 48,
+        height: 48,
+        decoration: const BoxDecoration(
+          shape: BoxShape.circle,
+          color: Colors.white24,
+        ),
+        child: Icon(icon, color: Colors.white),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,125 +1,40 @@
 import 'package:flutter/material.dart';
+import 'game_screen.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const CyberBrickSmasherApp());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class CyberBrickSmasherApp extends StatelessWidget {
+  const CyberBrickSmasherApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      title: 'Cyber Brick Smasher',
+      theme: ThemeData(useMaterial3: true),
+      home: const StartScreen(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
+class StartScreen extends StatelessWidget {
+  const StartScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
     return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
+      appBar: AppBar(title: const Text('Cyber Brick Smasher')),
       body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
+        child: ElevatedButton(
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const GameScreen()),
+            );
+          },
+          child: const Text('Start Game'),
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,10 +57,10 @@ flutter:
   # the material Icons class.
   uses-material-design: true
 
+  assets:
+    - assets/images/
+
   # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/to/resolution-aware-images

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,12 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_cyber_brick_smasher/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('Start screen shows Start Game button', (tester) async {
+    await tester.pumpWidget(const CyberBrickSmasherApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Start Game'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- introduce `_Block` class with `unbreakable` flag
- adjust collision logic to ignore unbreakable blocks and detect level completion
- display a "Level Complete!" dialog with restart button when only unbreakable blocks remain

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68751dc3f3b4832595d36970502a86e8