### PR TITLE
Add BallCollisionStrategy interface

### DIFF
--- a/lib/strategies/ball_collision_strategy.dart
+++ b/lib/strategies/ball_collision_strategy.dart
@@ -1,0 +1,23 @@
+import 'dart:ui';
+
+/// Represents the result of a ball-block collision.
+class BallCollisionResult {
+  final Offset newVelocity;
+  final bool destroyBlock;
+  final bool passThrough;
+
+  const BallCollisionResult({
+    required this.newVelocity,
+    required this.destroyBlock,
+    required this.passThrough,
+  });
+}
+
+/// Strategy interface for handling ball-block collisions.
+abstract class BallCollisionStrategy {
+  BallCollisionResult handleCollision({
+    required Offset velocity,
+    required Rect ballRect,
+    required Rect blockRect,
+  });
+}

--- a/lib/strategies/default_bounce_strategy.dart
+++ b/lib/strategies/default_bounce_strategy.dart
@@ -1,0 +1,30 @@
+import 'dart:ui';
+
+import 'ball_collision_strategy.dart';
+
+/// Default strategy for bouncing a ball off a block.
+class DefaultBounceStrategy implements BallCollisionStrategy {
+  @override
+  BallCollisionResult handleCollision({
+    required Offset velocity,
+    required Rect ballRect,
+    required Rect blockRect,
+  }) {
+    final intersection = ballRect.intersect(blockRect);
+    Offset newVelocity = velocity;
+
+    if (intersection.width >= intersection.height) {
+      // Vertical collision (top/bottom)
+      newVelocity = Offset(velocity.dx, -velocity.dy);
+    } else {
+      // Horizontal collision (left/right)
+      newVelocity = Offset(-velocity.dx, velocity.dy);
+    }
+
+    return BallCollisionResult(
+      newVelocity: newVelocity,
+      destroyBlock: true,
+      passThrough: false,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `BallCollisionResult` and `BallCollisionStrategy` to support flexible ball behavior
- implement `DefaultBounceStrategy` and use it for collisions

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687639d1d8248325a4801137b62a681a