### PR TITLE
Add BallCollisionStrategy interface

### DIFF
--- a/lib/strategies/ball_collision_strategy.dart
+++ b/lib/strategies/ball_collision_strategy.dart
@@ -1,0 +1,23 @@
+import 'dart:ui';
+
+/// Represents the result of a ball-block collision.
+class BallCollisionResult {
+  final Offset newVelocity;
+  final bool destroyBlock;
+  final bool passThrough;
+
+  const BallCollisionResult({
+    required this.newVelocity,
+    required this.destroyBlock,
+    required this.passThrough,
+  });
+}
+
+/// Strategy interface for handling ball-block collisions.
+abstract class BallCollisionStrategy {
+  BallCollisionResult handleCollision({
+    required Offset velocity,
+    required Rect ballRect,
+    required Rect blockRect,
+  });
+}

--- a/lib/strategies/default_bounce_strategy.dart
+++ b/lib/strategies/default_bounce_strategy.dart
@@ -1,0 +1,30 @@
+import 'dart:ui';
+
+import 'ball_collision_strategy.dart';
+
+/// Default strategy for bouncing a ball off a block.
+class DefaultBounceStrategy implements BallCollisionStrategy {
+  @override
+  BallCollisionResult handleCollision({
+    required Offset velocity,
+    required Rect ballRect,
+    required Rect blockRect,
+  }) {
+    final intersection = ballRect.intersect(blockRect);
+    Offset newVelocity = velocity;
+
+    if (intersection.width >= intersection.height) {
+      // Vertical collision (top/bottom)
+      newVelocity = Offset(velocity.dx, -velocity.dy);
+    } else {
+      // Horizontal collision (left/right)
+      newVelocity = Offset(-velocity.dx, velocity.dy);
+    }
+
+    return BallCollisionResult(
+      newVelocity: newVelocity,
+      destroyBlock: true,
+      passThrough: false,
+    );
+  }
+}

--- a/lib/strategies/fireball_collision_strategy.dart
+++ b/lib/strategies/fireball_collision_strategy.dart
@@ -1,0 +1,20 @@
+import 'dart:ui';
+
+import 'ball_collision_strategy.dart';
+
+/// Collision strategy for the fireball power-up. The ball does not bounce
+/// and passes through blocks while destroying them.
+class FireballCollisionStrategy implements BallCollisionStrategy {
+  @override
+  BallCollisionResult handleCollision({
+    required Offset velocity,
+    required Rect ballRect,
+    required Rect blockRect,
+  }) {
+    return BallCollisionResult(
+      newVelocity: velocity,
+      destroyBlock: true,
+      passThrough: true,
+    );
+  }
+}

--- a/lib/strategies/phaseball_collision_strategy.dart
+++ b/lib/strategies/phaseball_collision_strategy.dart
@@ -1,0 +1,20 @@
+import 'dart:ui';
+
+import 'ball_collision_strategy.dart';
+
+/// Collision strategy for the phaseball power-up. The ball does not bounce
+/// and passes through blocks without destroying them.
+class PhaseballCollisionStrategy implements BallCollisionStrategy {
+  @override
+  BallCollisionResult handleCollision({
+    required Offset velocity,
+    required Rect ballRect,
+    required Rect blockRect,
+  }) {
+    return BallCollisionResult(
+      newVelocity: velocity,
+      destroyBlock: false,
+      passThrough: true,
+    );
+  }
+}

--- a/lib/view_models/game_view_model.dart
+++ b/lib/view_models/game_view_model.dart
@@ -14,6 +14,10 @@ import '../models/special_block.dart';
 import '../models/unbreakable_block.dart';
 import '../factories/level_factory.dart';
 import '../utils/constants.dart';
+import '../strategies/ball_collision_strategy.dart';
+import '../strategies/default_bounce_strategy.dart';
+import '../strategies/fireball_collision_strategy.dart';
+import '../strategies/phaseball_collision_strategy.dart';
 
 enum GameState { playing, levelCompleted, gameOver, gameFinished }
 
@@ -37,6 +41,9 @@ class GameViewModel extends ChangeNotifier {
   Timer? _levelTransitionTimer;
 
   final Random _random = Random();
+
+  /// Strategy used for ball-block collisions.
+  BallCollisionStrategy ballCollisionStrategy = DefaultBounceStrategy();
 
   late Ball ball;
   int _currentLevel = 1;
@@ -153,6 +160,7 @@ class GameViewModel extends ChangeNotifier {
       position: const Offset(ballInitialX, ballInitialY),
       velocity: const Offset(ballInitialDX, ballInitialDY),
     );
+    ballCollisionStrategy = DefaultBounceStrategy();
     paddleX = paddleInitialX;
     activePowerUps.clear();
     powerUps.clear();
@@ -269,29 +277,34 @@ class GameViewModel extends ChangeNotifier {
       final rect = block.rect;
 
       if (ballRect.overlaps(rect)) {
-        if (!activePowerUps.contains(PowerUpType.fireball)) {
+        final result = ballCollisionStrategy.handleCollision(
+          velocity: ball.velocity,
+          ballRect: ballRect,
+          blockRect: rect,
+        );
+
+        var vel = result.newVelocity;
+        var pos = ball.position;
+
+        if (!result.passThrough) {
           final intersection = ballRect.intersect(rect);
-          var vel = ball.velocity;
-          var pos = ball.position;
 
           if (intersection.height >= intersection.width) {
-            vel = Offset(-vel.dx, vel.dy);
             pos = vel.dx > 0
                 ? Offset(rect.left - ballSize / 2, pos.dy)
                 : Offset(rect.right + ballSize / 2, pos.dy);
           } else {
-            vel = Offset(vel.dx, -vel.dy);
             pos = vel.dy > 0
                 ? Offset(pos.dx, rect.top - ballSize / 2)
                 : Offset(pos.dx, rect.bottom + ballSize / 2);
           }
-
-          ball
-            ..position = pos
-            ..velocity = vel;
         }
 
-        if (block.hit()) {
+        ball
+          ..position = pos
+          ..velocity = vel;
+
+        if (result.destroyBlock && block.hit()) {
           blocks.removeAt(i);
           score += 10;
 
@@ -392,6 +405,10 @@ class GameViewModel extends ChangeNotifier {
       activePowerUps.remove(type);
       if (type == PowerUpType.fireball && ball is Fireball) {
         ball = (ball as Fireball).ball;
+        ballCollisionStrategy = DefaultBounceStrategy();
+      }
+      if (type == PowerUpType.phaseball) {
+        ballCollisionStrategy = DefaultBounceStrategy();
       }
       if (type == PowerUpType.gun) {
         _gunFireTimer?.cancel();
@@ -405,6 +422,10 @@ class GameViewModel extends ChangeNotifier {
     }
     if (type == PowerUpType.fireball) {
       ball = Fireball(ball);
+      ballCollisionStrategy = FireballCollisionStrategy();
+    }
+    if (type == PowerUpType.phaseball) {
+      ballCollisionStrategy = PhaseballCollisionStrategy();
     }
     notifyListeners();
   }


### PR DESCRIPTION
## Summary
- introduce `BallCollisionResult` and `BallCollisionStrategy` to support flexible ball behavior
- implement `DefaultBounceStrategy` and use it for collisions
- add `FireballCollisionStrategy` and hook it up in the power-up logic
- create `PhaseballCollisionStrategy` for the phaseball power-up
- switch collision behavior when phaseball activates or expires

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687639d1d8248325a4801137b62a681a