### PR TITLE
Show ball power-up state via strategy

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -5,6 +5,8 @@ import '../models/block.dart';
 import '../models/power_up.dart';
 import '../utils/constants.dart';
 import '../view_models/game_view_model.dart';
+import '../strategies/fireball_collision_strategy.dart';
+import '../strategies/phaseball_collision_strategy.dart';
 
 class GameScreen extends StatefulWidget {
   const GameScreen({super.key});
@@ -98,10 +100,17 @@ class _GameScreenState extends State<GameScreen> {
                   alignment: Alignment(
                       2 * _model.ball.position.dx - 1,
                       2 * _model.ball.position.dy - 1),
-                  child: Image.asset(_model.activePowerUps
-                          .contains(PowerUpType.fireball)
-                      ? 'assets/images/ball_on_fire.png'
-                      : 'assets/images/ball.png'),
+                  child: Builder(
+                    builder: (_) {
+                      final strategy = _model.getCollisionStrategy();
+                      final image = strategy is FireballCollisionStrategy
+                          ? 'assets/images/ball_on_fire.png'
+                          : strategy is PhaseballCollisionStrategy
+                              ? 'assets/images/ball_phase.png'
+                              : 'assets/images/ball.png';
+                      return Image.asset(image);
+                    },
+                  ),
                 ),
                 Align(
                   alignment: Alignment.bottomLeft,

--- a/lib/view_models/game_view_model.dart
+++ b/lib/view_models/game_view_model.dart
@@ -42,6 +42,13 @@ class GameViewModel extends ChangeNotifier {
 
   final Random _random = Random();
 
+  /// Strategy used to resolve collisions between the ball and blocks.
+  late BallCollisionStrategy ballCollisionStrategy;
+
+  /// Returns the currently active collision strategy based on [activePowerUps].
+  BallCollisionStrategy getCollisionStrategy() =>
+      _getCollisionStrategy(activePowerUps);
+
   late Ball ball;
   int _currentLevel = 1;
   static const int _maxLevel = 5;


### PR DESCRIPTION
## Summary
- expose method to fetch active ball collision strategy
- get ball image based on `getCollisionStrategy()`

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764e26263c8325b68bf6ff4c903241