### PR TITLE
Fix ball-block reflection

### DIFF
--- a/lib/strategies/ball_collision_strategy.dart
+++ b/lib/strategies/ball_collision_strategy.dart
@@ -3,11 +3,13 @@ import 'dart:ui';
 /// Represents the result of a ball-block collision.
 class BallCollisionResult {
   final Offset newVelocity;
+  final Offset newPosition;
   final bool destroyBlock;
   final bool passThrough;
 
   const BallCollisionResult({
     required this.newVelocity,
+    required this.newPosition,
     required this.destroyBlock,
     required this.passThrough,
   });

--- a/lib/strategies/default_bounce_strategy.dart
+++ b/lib/strategies/default_bounce_strategy.dart
@@ -10,19 +10,39 @@ class DefaultBounceStrategy implements BallCollisionStrategy {
     required Rect ballRect,
     required Rect blockRect,
   }) {
+    final previousRect = ballRect.translate(-velocity.dx, -velocity.dy);
     final intersection = ballRect.intersect(blockRect);
-    Offset newVelocity = velocity;
+    var newVelocity = velocity;
+    var newRect = ballRect;
 
-    if (intersection.width >= intersection.height) {
-      // Vertical collision (top/bottom)
-      newVelocity = Offset(velocity.dx, -velocity.dy);
-    } else {
-      // Horizontal collision (left/right)
-      newVelocity = Offset(-velocity.dx, velocity.dy);
+    final cameFromLeft =
+        previousRect.right <= blockRect.left && ballRect.right >= blockRect.left;
+    final cameFromRight =
+        previousRect.left >= blockRect.right && ballRect.left <= blockRect.right;
+    final cameFromTop =
+        previousRect.bottom <= blockRect.top && ballRect.bottom >= blockRect.top;
+    final cameFromBottom =
+        previousRect.top >= blockRect.bottom && ballRect.top <= blockRect.bottom;
+
+    if (cameFromLeft) {
+      newVelocity = Offset(-newVelocity.dx, newVelocity.dy);
+      newRect = newRect.translate(-intersection.width, 0);
+    } else if (cameFromRight) {
+      newVelocity = Offset(-newVelocity.dx, newVelocity.dy);
+      newRect = newRect.translate(intersection.width, 0);
+    }
+
+    if (cameFromTop) {
+      newVelocity = Offset(newVelocity.dx, -newVelocity.dy);
+      newRect = newRect.translate(0, -intersection.height);
+    } else if (cameFromBottom) {
+      newVelocity = Offset(newVelocity.dx, -newVelocity.dy);
+      newRect = newRect.translate(0, intersection.height);
     }
 
     return BallCollisionResult(
       newVelocity: newVelocity,
+      newPosition: newRect.center,
       destroyBlock: true,
       passThrough: false,
     );

--- a/lib/strategies/fireball_collision_strategy.dart
+++ b/lib/strategies/fireball_collision_strategy.dart
@@ -13,6 +13,7 @@ class FireballCollisionStrategy implements BallCollisionStrategy {
   }) {
     return BallCollisionResult(
       newVelocity: velocity,
+      newPosition: ballRect.center,
       destroyBlock: true,
       passThrough: true,
     );

--- a/lib/strategies/phaseball_collision_strategy.dart
+++ b/lib/strategies/phaseball_collision_strategy.dart
@@ -13,6 +13,7 @@ class PhaseballCollisionStrategy implements BallCollisionStrategy {
   }) {
     return BallCollisionResult(
       newVelocity: velocity,
+      newPosition: ballRect.center,
       destroyBlock: false,
       passThrough: true,
     );

--- a/lib/view_models/game_view_model.dart
+++ b/lib/view_models/game_view_model.dart
@@ -309,7 +309,7 @@ class GameViewModel extends ChangeNotifier {
         );
 
         var vel = result.newVelocity;
-        var pos = ball.position;
+        var pos = result.newPosition;
         final clampedBlock = PhysicsHelper.clampVelocity(
           Vector2(vel.dx, vel.dy),
           minBallSpeed,
@@ -317,19 +317,7 @@ class GameViewModel extends ChangeNotifier {
         );
         vel = Offset(clampedBlock.x, clampedBlock.y);
 
-        if (!result.passThrough) {
-          final intersection = ballRect.intersect(rect);
-
-          if (intersection.height >= intersection.width) {
-            pos = vel.dx > 0
-                ? Offset(rect.left - ballSize / 2, pos.dy)
-                : Offset(rect.right + ballSize / 2, pos.dy);
-          } else {
-            pos = vel.dy > 0
-                ? Offset(pos.dx, rect.top - ballSize / 2)
-                : Offset(pos.dx, rect.bottom + ballSize / 2);
-          }
-        }
+        // The strategy already resolves overlap
 
         ball
           ..position = pos


### PR DESCRIPTION
## Summary
- calculate bounce direction using previous ball position
- reposition ball after bouncing so it doesn't overlap blocks
- return new position in `BallCollisionResult`
- use updated result in the game logic

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876829249bc8325977537943f921141