### PR TITLE
Introduce block factory and restructure models

### DIFF
--- a/lib/factories/block_factory.dart
+++ b/lib/factories/block_factory.dart
@@ -1,0 +1,54 @@
+import 'dart:math';
+
+import '../models/level_design.dart';
+import '../models/blocks/normal_block.dart';
+import '../models/blocks/unbreakable_block.dart';
+import '../models/blocks/special_block.dart';
+import '../models/block.dart';
+
+abstract class BlockFactory {
+  Block createBlock(BlockDescriptor descriptor);
+}
+
+class DefaultBlockFactory implements BlockFactory {
+  DefaultBlockFactory({Random? random}) : _random = random ?? Random();
+
+  final Random _random;
+
+  static const _normalImages = [
+    'assets/images/block_1.png',
+    'assets/images/block_2.png',
+    'assets/images/block_3.png',
+    'assets/images/block_4.png',
+  ];
+
+  @override
+  Block createBlock(BlockDescriptor descriptor) {
+    switch (descriptor.type) {
+      case 'normal':
+        final image = _normalImages[_random.nextInt(_normalImages.length)];
+        return NormalBlock(
+          position: descriptor.position,
+          size: descriptor.size,
+          image: image,
+        );
+      case 'unbreakable':
+        return UnbreakableBlock(
+          position: descriptor.position,
+          size: descriptor.size,
+        );
+      case 'special':
+        return SpecialBlock(
+          position: descriptor.position,
+          size: descriptor.size,
+        );
+      default:
+        final image = _normalImages[_random.nextInt(_normalImages.length)];
+        return NormalBlock(
+          position: descriptor.position,
+          size: descriptor.size,
+          image: image,
+        );
+    }
+  }
+}

--- a/lib/factories/level_factory.dart
+++ b/lib/factories/level_factory.dart
@@ -2,13 +2,13 @@ import 'dart:ui';
 
 import '../models/level_design.dart';
 
-/// Factory that generates [LevelDesign] instances for the given level number.
+/// Factory that provides block layouts for each level.
 class LevelFactory {
   static const double _blockWidth = 0.1;
   static const double _blockHeight = 0.05;
 
-  /// Returns a [LevelDesign] for the provided [levelNumber].
-  static LevelDesign createLevel(int levelNumber) {
+  /// Returns a list of [BlockDescriptor]s for the provided [levelNumber].
+  static List<BlockDescriptor> createLevel(int levelNumber) {
     switch (levelNumber) {
       case 1:
         return _level1();
@@ -25,8 +25,8 @@ class LevelFactory {
     }
   }
 
-  static LevelDesign _level1() {
-    return LevelDesign(levelNumber: 1, blocks: [
+  static List<BlockDescriptor> _level1() {
+    return [
       BlockDescriptor(
         position: const Offset(0.2, 0.2),
         size: const Size(_blockWidth, _blockHeight),
@@ -42,11 +42,11 @@ class LevelFactory {
         size: const Size(_blockWidth, _blockHeight),
         type: 'unbreakable',
       ),
-    ]);
+    ];
   }
 
-  static LevelDesign _level2() {
-    return LevelDesign(levelNumber: 2, blocks: [
+  static List<BlockDescriptor> _level2() {
+    return [
       BlockDescriptor(
         position: const Offset(0.2, 0.3),
         size: const Size(_blockWidth, _blockHeight),
@@ -67,11 +67,11 @@ class LevelFactory {
         size: const Size(_blockWidth, _blockHeight),
         type: 'special',
       ),
-    ]);
+    ];
   }
 
-  static LevelDesign _level3() {
-    return LevelDesign(levelNumber: 3, blocks: [
+  static List<BlockDescriptor> _level3() {
+    return [
       BlockDescriptor(
         position: const Offset(0.35, 0.35),
         size: const Size(_blockWidth, _blockHeight),
@@ -102,10 +102,10 @@ class LevelFactory {
         size: const Size(_blockWidth, _blockHeight),
         type: 'special',
       ),
-    ]);
+    ];
   }
 
-  static LevelDesign _level4() {
+  static List<BlockDescriptor> _level4() {
     final blocks = <BlockDescriptor>[];
     const startX = 0.1;
     const stepX = 0.12;
@@ -122,10 +122,10 @@ class LevelFactory {
         type: 'normal',
       ));
     }
-    return LevelDesign(levelNumber: 4, blocks: blocks);
+    return blocks;
   }
 
-  static LevelDesign _level5() {
+  static List<BlockDescriptor> _level5() {
     final blocks = <BlockDescriptor>[];
     // Vertical line
     for (int i = 0; i < 5; i++) {
@@ -151,6 +151,6 @@ class LevelFactory {
       size: const Size(_blockWidth, _blockHeight),
       type: 'special',
     ));
-    return LevelDesign(levelNumber: 5, blocks: blocks);
+    return blocks;
   }
 }

--- a/lib/models/blocks/normal_block.dart
+++ b/lib/models/blocks/normal_block.dart
@@ -1,4 +1,4 @@
-import 'block.dart';
+import '../block.dart';
 
 class NormalBlock extends Block {
   NormalBlock({required super.position, required super.size, required String image})

--- a/lib/models/blocks/special_block.dart
+++ b/lib/models/blocks/special_block.dart
@@ -1,4 +1,4 @@
-import 'block.dart';
+import '../block.dart';
 
 class SpecialBlock extends Block {
   SpecialBlock({required super.position, required super.size}) : super(hitPoints: 2);

--- a/lib/models/blocks/unbreakable_block.dart
+++ b/lib/models/blocks/unbreakable_block.dart
@@ -1,4 +1,4 @@
-import 'block.dart';
+import '../block.dart';
 
 class UnbreakableBlock extends Block {
   UnbreakableBlock({required super.position, required super.size})


### PR DESCRIPTION
## Summary
- move block models into `lib/models/blocks/`
- add `BlockFactory` and `DefaultBlockFactory`
- refactor `LevelFactory` to output `BlockDescriptor` lists
- create blocks via the factory in `GameViewModel`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68768e9bf42083258d082b48499bac53