### PR TITLE
Fix visual & logic size mismatch

### DIFF
--- a/lib/factories/level_factory.dart
+++ b/lib/factories/level_factory.dart
@@ -1,9 +1,10 @@
 import 'dart:ui';
 import '../models/level_design.dart';
+import '../utils/game_dimensions.dart';
 
 class LevelFactory {
-  static const double _blockWidth = 0.1;
-  static const double _blockHeight = 0.05;
+  static double get _blockWidth => GameDimensions.blockWidth;
+  static double get _blockHeight => GameDimensions.blockHeight;
 
   static List<BlockDescriptor> createLevel(int levelNumber) {
     switch (levelNumber) {

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import '../models/block.dart';
 import '../models/power_up.dart';
 import '../utils/constants.dart';
+import '../utils/game_dimensions.dart';
 import '../view_models/game_view_model.dart';
 import '../strategies/fireball_collision_strategy.dart';
 import '../strategies/phaseball_collision_strategy.dart';
@@ -43,6 +44,9 @@ class _GameScreenState extends State<GameScreen> {
         builder: (context, constraints) {
           final width = constraints.maxWidth;
           final height = constraints.maxHeight;
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            _model.initialize(Size(width, height));
+          });
           return RawKeyboardListener(
             focusNode: _model.focusNode,
             onKey: _handleKey,
@@ -71,35 +75,36 @@ class _GameScreenState extends State<GameScreen> {
                   ),
                 for (final p in _model.powerUps)
                   Positioned(
-                    left: (p.position.dx - powerUpSize / 2) * width,
-                    top: (p.position.dy - powerUpSize / 2) * height,
-                    width: powerUpSize * width,
-                    height: powerUpSize * height,
+                    left: (p.position.dx - GameDimensions.powerUpSize / 2) * width,
+                    top: (p.position.dy - GameDimensions.powerUpSize / 2) * height,
+                    width: GameDimensions.powerUpSize * width,
+                    height: GameDimensions.powerUpSize * height,
                     child: Image.asset(powerUpImage(p.type)),
                   ),
                 for (final proj in _model.projectiles)
                   Positioned(
-                    left: (proj.dx - projectileWidth / 2) * width,
-                    top: (proj.dy - projectileHeight / 2) * height,
-                    width: projectileWidth * width,
-                    height: projectileHeight * height,
+                    left: (proj.dx - GameDimensions.projectileWidth / 2) * width,
+                    top: (proj.dy - GameDimensions.projectileHeight / 2) * height,
+                    width: GameDimensions.projectileWidth * width,
+                    height: GameDimensions.projectileHeight * height,
                     child: Image.asset('assets/images/projectile.png'),
                   ),
-                Align(
-                  alignment: Alignment(2 * _model.paddleX - 1, 1),
-                  child: Padding(
-                    padding: const EdgeInsets.only(bottom: 48.0),
-                    child: Image.asset(
-                      _model.activePowerUps.contains(PowerUpType.gun)
-                          ? 'assets/images/paddle_with_gun.png'
-                          : 'assets/images/paddle.png',
-                    ),
+                Positioned(
+                  left: (_model.paddleX - GameDimensions.paddleHalfWidth) * width,
+                  top: (paddleY - GameDimensions.paddleHeight / 2) * height,
+                  width: GameDimensions.paddleHalfWidth * 2 * width,
+                  height: GameDimensions.paddleHeight * height,
+                  child: Image.asset(
+                    _model.activePowerUps.contains(PowerUpType.gun)
+                        ? 'assets/images/paddle_with_gun.png'
+                        : 'assets/images/paddle.png',
                   ),
                 ),
-                Align(
-                  alignment: Alignment(
-                      2 * _model.ball.position.dx - 1,
-                      2 * _model.ball.position.dy - 1),
+                Positioned(
+                  left: (_model.ball.position.dx - GameDimensions.ballSize / 2) * width,
+                  top: (_model.ball.position.dy - GameDimensions.ballSize / 2) * height,
+                  width: GameDimensions.ballSize * width,
+                  height: GameDimensions.ballSize * height,
                   child: Builder(
                     builder: (_) {
                       final strategy = _model.getCollisionStrategy();

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -8,7 +8,6 @@ const double maxBallSpeed = 0.007;
 const double paddleInitialX = 0.5;
 const double paddleSpeed = 0.02;
 const double paddleY = 0.95;
-const double paddleHalfWidth = 0.1;
 
 const int blockRows = 4;
 const int blockCols = 6;
@@ -16,7 +15,6 @@ const double blockSpacing = 0.02;
 const double blockTopOffset = 0.1;
 const double blockHeight = 0.05;
 
-const double ballSize = 0.04;
 const double powerUpSpeed = 0.01;
 const double projectileSpeed = 0.02;
 const double powerUpProbability = 1;
@@ -25,7 +23,8 @@ const Duration frameDuration = Duration(milliseconds: 16);
 const Duration powerUpDuration = Duration(seconds: 7);
 const Duration gunFireInterval = Duration(milliseconds: 500);
 
-const double powerUpSize = 0.05;
-const double projectileWidth = 0.02;
-const double projectileHeight = 0.04;
+// Sizes are provided by GameDimensions
+const double powerUpSize = 0.05; // unused, kept for backward compatibility
+const double projectileWidth = 0.02; // unused
+const double projectileHeight = 0.04; // unused
 const double projectileStartY = 0.93;

--- a/lib/utils/game_dimensions.dart
+++ b/lib/utils/game_dimensions.dart
@@ -1,0 +1,35 @@
+import 'dart:ui';
+
+/// Handles conversion between pixel-based asset sizes and the logical
+/// coordinate system used by the game logic (0..1 on both axes).
+class GameDimensions {
+  // Exact pixel dimensions of the game assets.
+  static const double blockPixelWidth = 32;
+  static const double blockPixelHeight = 16;
+  static const double paddlePixelWidth = 64;
+  static const double paddlePixelHeight = 16;
+  static const double ballPixelSize = 16;
+  static const double powerUpPixelSize = 24;
+  static const double projectilePixelWidth = 8;
+  static const double projectilePixelHeight = 16;
+
+  static double _screenWidth = 1;
+  static double _screenHeight = 1;
+
+  /// Updates the cached screen size. Must be called once the screen
+  /// dimensions are known (e.g. from [LayoutBuilder]).
+  static void update(Size size) {
+    _screenWidth = size.width;
+    _screenHeight = size.height;
+  }
+
+  // Normalized sizes derived from the pixel dimensions.
+  static double get ballSize => ballPixelSize / _screenWidth;
+  static double get paddleHalfWidth => (paddlePixelWidth / _screenWidth) / 2;
+  static double get paddleHeight => paddlePixelHeight / _screenHeight;
+  static double get blockWidth => blockPixelWidth / _screenWidth;
+  static double get blockHeight => blockPixelHeight / _screenHeight;
+  static double get powerUpSize => powerUpPixelSize / _screenWidth;
+  static double get projectileWidth => projectilePixelWidth / _screenWidth;
+  static double get projectileHeight => projectilePixelHeight / _screenHeight;
+}

--- a/lib/view_models/game_view_model.dart
+++ b/lib/view_models/game_view_model.dart
@@ -16,6 +16,7 @@ import '../models/blocks/unbreakable_block.dart';
 import '../factories/level_factory.dart';
 import '../factories/block_factory.dart';
 import '../utils/constants.dart';
+import '../utils/game_dimensions.dart';
 import '../utils/physics_helper.dart';
 import '../strategies/ball_collision_strategy.dart';
 import '../strategies/default_bounce_strategy.dart';
@@ -28,11 +29,20 @@ class GameViewModel extends ChangeNotifier {
   GameViewModel({BlockFactory? blockFactory}) {
     _blockFactory = blockFactory ?? DefaultBlockFactory(random: _random);
     _focusNode = FocusNode();
+  }
+
+  bool _initialized = false;
+
+  /// Must be called once the screen size is known to set up sizes and start the game.
+  void initialize(Size size) {
+    if (_initialized) return;
+    GameDimensions.update(size);
+    resetGame();
+    _gameTimer = Timer.periodic(frameDuration, _update);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _focusNode.requestFocus();
     });
-    resetGame();
-    _gameTimer = Timer.periodic(frameDuration, _update);
+    _initialized = true;
   }
 
   late FocusNode _focusNode;
@@ -246,8 +256,9 @@ class GameViewModel extends ChangeNotifier {
     // 🧠 Paddle-Kollision mit realistischer Reflexion
     if (ball.velocity.dy > 0 &&
         ball.position.dy >= paddleY &&
-        (ball.position.dx - paddleX).abs() <= paddleHalfWidth) {
-      final hitOffset = (ball.position.dx - paddleX) / paddleHalfWidth;
+        (ball.position.dx - paddleX).abs() <= GameDimensions.paddleHalfWidth) {
+      final hitOffset =
+          (ball.position.dx - paddleX) / GameDimensions.paddleHalfWidth;
       final clampedOffset = hitOffset.clamp(-1.0, 1.0);
       const maxBounceAngle = 0.03;
 
@@ -265,10 +276,10 @@ class GameViewModel extends ChangeNotifier {
 
     // 🎯 Ball-zu-Block-Kollision
     final ballRect = Rect.fromLTWH(
-      ball.position.dx - ballSize / 2,
-      ball.position.dy - ballSize / 2,
-      ballSize,
-      ballSize,
+      ball.position.dx - GameDimensions.ballSize / 2,
+      ball.position.dy - GameDimensions.ballSize / 2,
+      GameDimensions.ballSize,
+      GameDimensions.ballSize,
     );
 
     final strategy = _getCollisionStrategy(activePowerUps);
@@ -327,7 +338,7 @@ class GameViewModel extends ChangeNotifier {
       }
 
       if (newPos.dy >= paddleY &&
-          (newPos.dx - paddleX).abs() <= paddleHalfWidth) {
+          (newPos.dx - paddleX).abs() <= GameDimensions.paddleHalfWidth) {
         powerUps.removeAt(i);
         _activatePowerUp(p.type);
         continue;
@@ -341,10 +352,10 @@ class GameViewModel extends ChangeNotifier {
       final newPos = projectiles[i].translate(0, -projectileSpeed);
       bool remove = false;
       final projRect = Rect.fromLTWH(
-        newPos.dx - projectileWidth / 2,
-        newPos.dy - projectileHeight / 2,
-        projectileWidth,
-        projectileHeight,
+        newPos.dx - GameDimensions.projectileWidth / 2,
+        newPos.dy - GameDimensions.projectileHeight / 2,
+        GameDimensions.projectileWidth,
+        GameDimensions.projectileHeight,
       );
 
       for (int j = 0; j < blocks.length; j++) {


### PR DESCRIPTION
## Summary
- add `GameDimensions` to centralize pixel sizes
- compute block dimensions from `GameDimensions`
- initialize the game after screen size is known
- render paddle, ball and powerups using calculated sizes
- update constants and collision logic to use new dimensions

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a921f15648325830faa2564d30149