### PR TITLE
Add magnet power-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
 # flutter_cyber_brick_smasher
 
-A new Flutter project.
+Cyber Brick Smasher is a simple Flutter game that follows a basic
+Model-View-ViewModel (MVVM) approach. The game logic lives inside the
+`GameViewModel` while `GameScreen` renders the state. This separation
+makes it easier to test and extend the game mechanics.
+
+The physics interactions use the **Strategy pattern**. Different
+strategies handle block collisions and how the ball bounces off the
+paddle. By encapsulating these behaviors, new effects like fireball or
+alternative paddle mechanics can be added without changing the game
+loop. For instance, the fireball collision logic delegates to the
+default bounce strategy when hitting unbreakable blocks, showing how
+strategies can be composed for flexible behavior.
+
+The magnet power-up temporarily overrides these strategies by holding
+the ball on the paddle. A simple timer releases the ball after four
+seconds so the existing collision strategies continue to work without
+modification.
+
+When the multiball power-up is collected, a **Composite pattern**
+manages several `Ball` instances at once. The `BallManager` treats the
+collection of balls like a single entity so the game loop can update,
+render, and remove them uniformly.
 
 ## Getting Started
 

--- a/lib/factories/level_factory.dart
+++ b/lib/factories/level_factory.dart
@@ -1,9 +1,10 @@
 import 'dart:ui';
 import '../models/level_design.dart';
+import '../utils/game_dimensions.dart';
 
 class LevelFactory {
-  static const double _blockWidth = 0.1;
-  static const double _blockHeight = 0.05;
+  static double get _blockWidth => GameDimensions.blockWidth;
+  static double get _blockHeight => GameDimensions.blockHeight;
 
   static List<BlockDescriptor> createLevel(int levelNumber) {
     switch (levelNumber) {

--- a/lib/managers/ball_manager.dart
+++ b/lib/managers/ball_manager.dart
@@ -1,0 +1,32 @@
+import '../models/ball.dart';
+
+/// Manages a collection of balls using the composite pattern.
+/// The game can treat the manager like a single entity that
+/// updates and removes balls uniformly.
+class BallManager {
+  final List<Ball> _balls = [];
+
+  List<Ball> get balls => _balls;
+
+  /// Adds a ball to the manager.
+  void addBall(Ball ball) => _balls.add(ball);
+
+  /// Iterates over all balls and calls [action] on each.
+  void forEach(void Function(Ball ball) action) {
+    for (final b in List<Ball>.from(_balls)) {
+      action(b);
+    }
+  }
+
+  /// Removes balls that have moved off the bottom of the screen.
+  void removeOffscreen() {
+    for (int i = _balls.length - 1; i >= 0; i--) {
+      if (_balls[i].position.dy >= 1.0) {
+        _balls.removeAt(i);
+      }
+    }
+  }
+
+  bool get isEmpty => _balls.isEmpty;
+}
+

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import '../models/block.dart';
 import '../models/power_up.dart';
 import '../utils/constants.dart';
+import '../utils/game_dimensions.dart';
 import '../view_models/game_view_model.dart';
 import '../strategies/fireball_collision_strategy.dart';
 import '../strategies/phaseball_collision_strategy.dart';
@@ -43,6 +44,9 @@ class _GameScreenState extends State<GameScreen> {
         builder: (context, constraints) {
           final width = constraints.maxWidth;
           final height = constraints.maxHeight;
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            _model.initialize(Size(width, height));
+          });
           return RawKeyboardListener(
             focusNode: _model.focusNode,
             onKey: _handleKey,
@@ -71,47 +75,49 @@ class _GameScreenState extends State<GameScreen> {
                   ),
                 for (final p in _model.powerUps)
                   Positioned(
-                    left: (p.position.dx - powerUpSize / 2) * width,
-                    top: (p.position.dy - powerUpSize / 2) * height,
-                    width: powerUpSize * width,
-                    height: powerUpSize * height,
+                    left: (p.position.dx - GameDimensions.powerUpSize / 2) * width,
+                    top: (p.position.dy - GameDimensions.powerUpSize / 2) * height,
+                    width: GameDimensions.powerUpSize * width,
+                    height: GameDimensions.powerUpSize * height,
                     child: Image.asset(powerUpImage(p.type)),
                   ),
                 for (final proj in _model.projectiles)
                   Positioned(
-                    left: (proj.dx - projectileWidth / 2) * width,
-                    top: (proj.dy - projectileHeight / 2) * height,
-                    width: projectileWidth * width,
-                    height: projectileHeight * height,
+                    left: (proj.dx - GameDimensions.projectileWidth / 2) * width,
+                    top: (proj.dy - GameDimensions.projectileHeight / 2) * height,
+                    width: GameDimensions.projectileWidth * width,
+                    height: GameDimensions.projectileHeight * height,
                     child: Image.asset('assets/images/projectile.png'),
                   ),
-                Align(
-                  alignment: Alignment(2 * _model.paddleX - 1, 1),
-                  child: Padding(
-                    padding: const EdgeInsets.only(bottom: 48.0),
-                    child: Image.asset(
-                      _model.activePowerUps.contains(PowerUpType.gun)
-                          ? 'assets/images/paddle_with_gun.png'
-                          : 'assets/images/paddle.png',
+                Positioned(
+                  left: (_model.paddleX - GameDimensions.paddleHalfWidth) * width,
+                  top: (paddleY - GameDimensions.paddleHeight / 2) * height,
+                  width: GameDimensions.paddleHalfWidth * 2 * width,
+                  height: GameDimensions.paddleHeight * height,
+                  child: Image.asset(
+                    _model.activePowerUps.contains(PowerUpType.gun)
+                        ? 'assets/images/paddle_with_gun.png'
+                        : 'assets/images/paddle.png',
+                  ),
+                ),
+                for (final ball in _model.balls)
+                  Positioned(
+                    left: (ball.position.dx - GameDimensions.ballSize / 2) * width,
+                    top: (ball.position.dy - GameDimensions.ballSize / 2) * height,
+                    width: GameDimensions.ballSize * width,
+                    height: GameDimensions.ballSize * height,
+                    child: Builder(
+                      builder: (_) {
+                        final strategy = _model.getCollisionStrategy();
+                        final image = strategy is FireballCollisionStrategy
+                            ? 'assets/images/ball_on_fire.png'
+                            : strategy is PhaseballCollisionStrategy
+                                ? 'assets/images/ball_phase.png'
+                                : 'assets/images/ball.png';
+                        return Image.asset(image);
+                      },
                     ),
                   ),
-                ),
-                Align(
-                  alignment: Alignment(
-                      2 * _model.ball.position.dx - 1,
-                      2 * _model.ball.position.dy - 1),
-                  child: Builder(
-                    builder: (_) {
-                      final strategy = _model.getCollisionStrategy();
-                      final image = strategy is FireballCollisionStrategy
-                          ? 'assets/images/ball_on_fire.png'
-                          : strategy is PhaseballCollisionStrategy
-                              ? 'assets/images/ball_phase.png'
-                              : 'assets/images/ball.png';
-                      return Image.asset(image);
-                    },
-                  ),
-                ),
                 Align(
                   alignment: Alignment.bottomLeft,
                   child: Padding(

--- a/lib/strategies/ball_collision_strategy.dart
+++ b/lib/strategies/ball_collision_strategy.dart
@@ -1,5 +1,7 @@
 import 'dart:ui';
 
+import '../models/block.dart';
+
 /// Represents the result of a ball-block collision.
 class BallCollisionResult {
   final Offset newVelocity;
@@ -21,5 +23,6 @@ abstract class BallCollisionStrategy {
     required Offset velocity,
     required Rect ballRect,
     required Rect blockRect,
+    required Block block,
   });
 }

--- a/lib/strategies/default_bounce_strategy.dart
+++ b/lib/strategies/default_bounce_strategy.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'ball_collision_strategy.dart';
+import '../models/block.dart';
 
 /// Default strategy for bouncing a ball off a block.
 class DefaultBounceStrategy implements BallCollisionStrategy {
@@ -9,6 +10,7 @@ class DefaultBounceStrategy implements BallCollisionStrategy {
     required Offset velocity,
     required Rect ballRect,
     required Rect blockRect,
+    required Block block,
   }) {
     final previousRect = ballRect.translate(-velocity.dx, -velocity.dy);
     final intersection = ballRect.intersect(blockRect);

--- a/lib/strategies/fireball_collision_strategy.dart
+++ b/lib/strategies/fireball_collision_strategy.dart
@@ -1,6 +1,9 @@
 import 'dart:ui';
 
 import 'ball_collision_strategy.dart';
+import 'default_bounce_strategy.dart';
+import '../models/block.dart';
+import '../models/blocks/unbreakable_block.dart';
 
 /// Collision strategy for the fireball power-up. The ball does not bounce
 /// and passes through blocks while destroying them.
@@ -10,7 +13,17 @@ class FireballCollisionStrategy implements BallCollisionStrategy {
     required Offset velocity,
     required Rect ballRect,
     required Rect blockRect,
+    required Block block,
   }) {
+    if (block is UnbreakableBlock) {
+      return DefaultBounceStrategy().handleCollision(
+        velocity: velocity,
+        ballRect: ballRect,
+        blockRect: blockRect,
+        block: block,
+      );
+    }
+
     return BallCollisionResult(
       newVelocity: velocity,
       newPosition: ballRect.center,

--- a/lib/strategies/paddle_bounce_strategy.dart
+++ b/lib/strategies/paddle_bounce_strategy.dart
@@ -1,0 +1,44 @@
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:vector_math/vector_math.dart' show Vector2;
+
+import '../utils/constants.dart';
+import '../utils/game_dimensions.dart';
+import '../utils/physics_helper.dart';
+
+/// Strategy interface for calculating the ball's bounce when it hits the paddle.
+abstract class PaddleBounceStrategy {
+  /// Returns the new velocity for the ball after it hits the paddle.
+  Offset calculateBounce({
+    required Offset ballPosition,
+    required Offset ballVelocity,
+    required double paddleX,
+  });
+}
+
+/// Classic arcade style bounce calculation used in games like Arkanoid.
+class ClassicPaddleBounceStrategy implements PaddleBounceStrategy {
+  @override
+  Offset calculateBounce({
+    required Offset ballPosition,
+    required Offset ballVelocity,
+    required double paddleX,
+  }) {
+    final relativeIntersectX = ballPosition.dx - paddleX;
+    final normalizedRelativeIntersectionX =
+        (relativeIntersectX / GameDimensions.paddleHalfWidth).clamp(-1.0, 1.0);
+    final bounceAngle = normalizedRelativeIntersectionX * pi / 3; // max 60°
+
+    final speed = ballVelocity.distance;
+    final newDx = speed * sin(bounceAngle);
+    final newDy = -speed * cos(bounceAngle); // always upward
+
+    final clamped = PhysicsHelper.clampVelocity(
+      Vector2(newDx, newDy),
+      minBallSpeed,
+      maxBallSpeed,
+    );
+    return Offset(clamped.x, clamped.y);
+  }
+}

--- a/lib/strategies/phaseball_collision_strategy.dart
+++ b/lib/strategies/phaseball_collision_strategy.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'ball_collision_strategy.dart';
+import '../models/block.dart';
 
 /// Collision strategy for the phaseball power-up. The ball does not bounce
 /// and passes through blocks without destroying them.
@@ -10,6 +11,7 @@ class PhaseballCollisionStrategy implements BallCollisionStrategy {
     required Offset velocity,
     required Rect ballRect,
     required Rect blockRect,
+    required Block block,
   }) {
     return BallCollisionResult(
       newVelocity: velocity,

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -8,7 +8,6 @@ const double maxBallSpeed = 0.007;
 const double paddleInitialX = 0.5;
 const double paddleSpeed = 0.02;
 const double paddleY = 0.95;
-const double paddleHalfWidth = 0.1;
 
 const int blockRows = 4;
 const int blockCols = 6;
@@ -16,7 +15,6 @@ const double blockSpacing = 0.02;
 const double blockTopOffset = 0.1;
 const double blockHeight = 0.05;
 
-const double ballSize = 0.04;
 const double powerUpSpeed = 0.01;
 const double projectileSpeed = 0.02;
 const double powerUpProbability = 1;
@@ -25,7 +23,14 @@ const Duration frameDuration = Duration(milliseconds: 16);
 const Duration powerUpDuration = Duration(seconds: 7);
 const Duration gunFireInterval = Duration(milliseconds: 500);
 
-const double powerUpSize = 0.05;
-const double projectileWidth = 0.02;
-const double projectileHeight = 0.04;
-const double projectileStartY = 0.93;
+/// Duration for which the magnet power-up holds the ball on the paddle.
+const Duration magnetHoldDuration = Duration(seconds: 4);
+
+/// How many projectile pairs the gun can fire before deactivating.
+const int maxGunShots = 20;
+
+// Sizes are provided by GameDimensions
+const double powerUpSize = 0.05; // unused, kept for backward compatibility
+const double projectileWidth = 0.02; // unused
+const double projectileHeight = 0.04; // unused
+const double projectileStartY = 0.93; // unused

--- a/lib/utils/game_dimensions.dart
+++ b/lib/utils/game_dimensions.dart
@@ -1,0 +1,35 @@
+import 'dart:ui';
+
+/// Handles conversion between pixel-based asset sizes and the logical
+/// coordinate system used by the game logic (0..1 on both axes).
+class GameDimensions {
+  // Exact pixel dimensions of the game assets.
+  static const double blockPixelWidth = 32;
+  static const double blockPixelHeight = 16;
+  static const double paddlePixelWidth = 64;
+  static const double paddlePixelHeight = 16;
+  static const double ballPixelSize = 16;
+  static const double powerUpPixelSize = 24;
+  static const double projectilePixelWidth = 8;
+  static const double projectilePixelHeight = 16;
+
+  static double _screenWidth = 1;
+  static double _screenHeight = 1;
+
+  /// Updates the cached screen size. Must be called once the screen
+  /// dimensions are known (e.g. from [LayoutBuilder]).
+  static void update(Size size) {
+    _screenWidth = size.width;
+    _screenHeight = size.height;
+  }
+
+  // Normalized sizes derived from the pixel dimensions.
+  static double get ballSize => ballPixelSize / _screenWidth;
+  static double get paddleHalfWidth => (paddlePixelWidth / _screenWidth) / 2;
+  static double get paddleHeight => paddlePixelHeight / _screenHeight;
+  static double get blockWidth => blockPixelWidth / _screenWidth;
+  static double get blockHeight => blockPixelHeight / _screenHeight;
+  static double get powerUpSize => powerUpPixelSize / _screenWidth;
+  static double get projectileWidth => projectilePixelWidth / _screenWidth;
+  static double get projectileHeight => projectilePixelHeight / _screenHeight;
+}

--- a/lib/view_models/game_view_model.dart
+++ b/lib/view_models/game_view_model.dart
@@ -8,6 +8,7 @@ import 'package:vector_math/vector_math.dart';
 
 import '../models/ball.dart';
 import '../models/ball_decorator.dart';
+import '../managers/ball_manager.dart';
 import '../models/block.dart';
 import '../models/blocks/normal_block.dart';
 import '../models/power_up.dart';
@@ -16,23 +17,39 @@ import '../models/blocks/unbreakable_block.dart';
 import '../factories/level_factory.dart';
 import '../factories/block_factory.dart';
 import '../utils/constants.dart';
+import '../utils/game_dimensions.dart';
 import '../utils/physics_helper.dart';
 import '../strategies/ball_collision_strategy.dart';
 import '../strategies/default_bounce_strategy.dart';
+import '../strategies/paddle_bounce_strategy.dart';
 import '../strategies/fireball_collision_strategy.dart';
 import '../strategies/phaseball_collision_strategy.dart';
 
 enum GameState { playing, levelCompleted, gameOver, gameFinished }
 
 class GameViewModel extends ChangeNotifier {
-  GameViewModel({BlockFactory? blockFactory}) {
+  GameViewModel({
+    BlockFactory? blockFactory,
+    PaddleBounceStrategy? paddleBounceStrategy,
+  }) {
     _blockFactory = blockFactory ?? DefaultBlockFactory(random: _random);
     _focusNode = FocusNode();
+    this.paddleBounceStrategy =
+        paddleBounceStrategy ?? ClassicPaddleBounceStrategy();
+  }
+
+  bool _initialized = false;
+
+  /// Must be called once the screen size is known to set up sizes and start the game.
+  void initialize(Size size) {
+    if (_initialized) return;
+    GameDimensions.update(size);
+    resetGame();
+    _gameTimer = Timer.periodic(frameDuration, _update);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _focusNode.requestFocus();
     });
-    resetGame();
-    _gameTimer = Timer.periodic(frameDuration, _update);
+    _initialized = true;
   }
 
   late FocusNode _focusNode;
@@ -42,6 +59,9 @@ class GameViewModel extends ChangeNotifier {
   Timer? _leftTimer;
   Timer? _rightTimer;
   Timer? _gunFireTimer;
+  int _gunShotsRemaining = 0;
+  Timer? _magnetTimer;
+  bool _magnetActive = false;
   Timer? _levelTransitionTimer;
 
   final Random _random = Random();
@@ -50,11 +70,16 @@ class GameViewModel extends ChangeNotifier {
   /// Strategy used to resolve collisions between the ball and blocks.
   late BallCollisionStrategy ballCollisionStrategy;
 
+  /// Strategy used to compute the ball's reflection when hitting the paddle.
+  late PaddleBounceStrategy paddleBounceStrategy;
+
   /// Returns the currently active collision strategy based on [activePowerUps].
   BallCollisionStrategy getCollisionStrategy() =>
       _getCollisionStrategy(activePowerUps);
 
-  late Ball ball;
+  /// Manages all active balls in the game.
+  final BallManager ballManager = BallManager();
+  List<Ball> get balls => ballManager.balls;
   int _currentLevel = 1;
   static const int _maxLevel = 5;
   GameState _state = GameState.playing;
@@ -137,6 +162,7 @@ class GameViewModel extends ChangeNotifier {
     _leftTimer?.cancel();
     _rightTimer?.cancel();
     _gunFireTimer?.cancel();
+    _magnetTimer?.cancel();
     _levelTransitionTimer?.cancel();
     notifyListeners();
     _levelTransitionTimer?.cancel();
@@ -160,14 +186,18 @@ class GameViewModel extends ChangeNotifier {
     _leftTimer?.cancel();
     _rightTimer?.cancel();
     _gunFireTimer?.cancel();
+    _magnetTimer?.cancel();
     _levelTransitionTimer?.cancel();
     notifyListeners();
   }
 
   void _setupLevel() {
-    ball = Ball(
-      position: const Offset(ballInitialX, ballInitialY),
-      velocity: const Offset(ballInitialDX, ballInitialDY),
+    ballManager.balls.clear();
+    ballManager.addBall(
+      Ball(
+        position: const Offset(ballInitialX, ballInitialY),
+        velocity: const Offset(ballInitialDX, ballInitialDY),
+      ),
     );
     ballCollisionStrategy = DefaultBounceStrategy();
     paddleX = paddleInitialX;
@@ -179,6 +209,9 @@ class GameViewModel extends ChangeNotifier {
     }
     _timers.clear();
     _gunFireTimer?.cancel();
+    _gunShotsRemaining = 0;
+    _magnetTimer?.cancel();
+    _magnetActive = false;
     _leftTimer?.cancel();
     _rightTimer?.cancel();
     blocks.clear();
@@ -212,109 +245,121 @@ class GameViewModel extends ChangeNotifier {
   void _update(Timer timer) {
     if (_state != GameState.playing) return;
 
-    final clampedStart = PhysicsHelper.clampVelocity(
-      Vector2(ball.velocity.dx, ball.velocity.dy),
-      minBallSpeed,
-      maxBallSpeed,
-    );
-    ball.velocity = Offset(clampedStart.x, clampedStart.y);
-
-    ball.update();
-    var pos = ball.position;
-    var vel = ball.velocity;
-
-    // Wände
-    if (pos.dx <= 0 || pos.dx >= 1) {
-      vel = Offset(-vel.dx, vel.dy);
-      pos = Offset(pos.dx.clamp(0.0, 1.0), pos.dy);
+    if (_magnetActive && balls.isNotEmpty) {
+      final holdY = paddleY -
+          GameDimensions.paddleHeight / 2 -
+          GameDimensions.ballSize / 2;
+      balls.first
+        ..position = Offset(paddleX, holdY)
+        ..velocity = Offset.zero;
+      notifyListeners();
+      return;
     }
-    // Oben
-    if (pos.dy <= 0) {
-      vel = Offset(vel.dx, -vel.dy);
-      pos = Offset(pos.dx, pos.dy.clamp(0.0, 1.0));
-    }
-
-    final clampedWall = PhysicsHelper.clampVelocity(
-      Vector2(vel.dx, vel.dy),
-      minBallSpeed,
-      maxBallSpeed,
-    );
-    ball
-      ..position = pos
-      ..velocity = Offset(clampedWall.x, clampedWall.y);
-
-    // 🧠 Paddle-Kollision mit realistischer Reflexion
-    if (ball.velocity.dy > 0 &&
-        ball.position.dy >= paddleY &&
-        (ball.position.dx - paddleX).abs() <= paddleHalfWidth) {
-      final hitOffset = (ball.position.dx - paddleX) / paddleHalfWidth;
-      final clampedOffset = hitOffset.clamp(-1.0, 1.0);
-      const maxBounceAngle = 0.03;
-
-      final newDx = clampedOffset * maxBounceAngle;
-      final newDy = -ball.velocity.dy.abs();
-
-      final clampedBounce = PhysicsHelper.clampVelocity(
-        Vector2(newDx, newDy),
-        minBallSpeed,
-        maxBallSpeed,
-      );
-      ball.velocity = Offset(clampedBounce.x, clampedBounce.y);
-      ball.position = Offset(ball.position.dx, paddleY);
-    }
-
-    // 🎯 Ball-zu-Block-Kollision
-    final ballRect = Rect.fromLTWH(
-      ball.position.dx - ballSize / 2,
-      ball.position.dy - ballSize / 2,
-      ballSize,
-      ballSize,
-    );
 
     final strategy = _getCollisionStrategy(activePowerUps);
 
-    for (int i = 0; i < blocks.length; i++) {
-      final block = blocks[i];
-      final rect = block.rect;
+    ballManager.forEach((ball) {
+      final clampedStart = PhysicsHelper.clampVelocity(
+        Vector2(ball.velocity.dx, ball.velocity.dy),
+        minBallSpeed,
+        maxBallSpeed,
+      );
+      ball.velocity = Offset(clampedStart.x, clampedStart.y);
 
-      if (ballRect.overlaps(rect)) {
-        final result = strategy.handleCollision(
-          velocity: ball.velocity,
-          ballRect: ballRect,
-          blockRect: rect,
+      ball.update();
+      var pos = ball.position;
+      var vel = ball.velocity;
+
+      // Wände
+      if (pos.dx <= 0 || pos.dx >= 1) {
+        vel = Offset(-vel.dx, vel.dy);
+        pos = Offset(pos.dx.clamp(0.0, 1.0), pos.dy);
+      }
+      // Oben
+      if (pos.dy <= 0) {
+        vel = Offset(vel.dx, -vel.dy);
+        pos = Offset(pos.dx, pos.dy.clamp(0.0, 1.0));
+      }
+
+      final clampedWall = PhysicsHelper.clampVelocity(
+        Vector2(vel.dx, vel.dy),
+        minBallSpeed,
+        maxBallSpeed,
+      );
+      ball
+        ..position = pos
+        ..velocity = Offset(clampedWall.x, clampedWall.y);
+
+      // 🧠 Paddle-Kollision mit realistischer Reflexion
+      if (ball.velocity.dy > 0 &&
+          ball.position.dy >= paddleY &&
+          (ball.position.dx - paddleX).abs() <=
+              GameDimensions.paddleHalfWidth) {
+        final newVel = paddleBounceStrategy.calculateBounce(
+          ballPosition: ball.position,
+          ballVelocity: ball.velocity,
+          paddleX: paddleX,
         );
-
-        var vel = result.newVelocity;
-        var pos = result.newPosition;
-        final clampedBlock = PhysicsHelper.clampVelocity(
-          Vector2(vel.dx, vel.dy),
-          minBallSpeed,
-          maxBallSpeed,
-        );
-        vel = Offset(clampedBlock.x, clampedBlock.y);
-
-        // The strategy already resolves overlap
-
         ball
-          ..position = pos
-          ..velocity = vel;
+          ..velocity = newVel
+          ..position = Offset(ball.position.dx, paddleY);
+      }
 
-        if (result.destroyBlock && block.hit()) {
-          blocks.removeAt(i);
-          score += 10;
+      // 🎯 Ball-zu-Block-Kollision
+      final ballRect = Rect.fromLTWH(
+        ball.position.dx - GameDimensions.ballSize / 2,
+        ball.position.dy - GameDimensions.ballSize / 2,
+        GameDimensions.ballSize,
+        GameDimensions.ballSize,
+      );
 
-          if (_random.nextDouble() < powerUpProbability) {
-            final types = PowerUpType.values;
-            final randomType = types[_random.nextInt(types.length)];
-            powerUps.add(FallingPowerUp(
-              type: randomType,
-              position: rect.center,
-            ));
+      for (int i = 0; i < blocks.length; i++) {
+        final block = blocks[i];
+        final rect = block.rect;
+
+        if (ballRect.overlaps(rect)) {
+          final result = strategy.handleCollision(
+            velocity: ball.velocity,
+            ballRect: ballRect,
+            blockRect: rect,
+            block: block,
+          );
+
+          var vel = result.newVelocity;
+          var pos = result.newPosition;
+          final clampedBlock = PhysicsHelper.clampVelocity(
+            Vector2(vel.dx, vel.dy),
+            minBallSpeed,
+            maxBallSpeed,
+          );
+          vel = Offset(clampedBlock.x, clampedBlock.y);
+
+          // The strategy already resolves overlap
+
+          ball
+            ..position = pos
+            ..velocity = vel;
+
+          if (result.destroyBlock && block.hit()) {
+            blocks.removeAt(i);
+            score += 10;
+
+            if (_random.nextDouble() < powerUpProbability) {
+              final types = PowerUpType.values;
+              final randomType = types[_random.nextInt(types.length)];
+              powerUps.add(FallingPowerUp(
+                type: randomType,
+                position: rect.center,
+              ));
+            }
+          }
+
+          if (!result.passThrough) {
+            break;
           }
         }
-        break;
       }
-    }
+    });
 
     // ⬇️ Powerups
     for (int i = powerUps.length - 1; i >= 0; i--) {
@@ -327,7 +372,7 @@ class GameViewModel extends ChangeNotifier {
       }
 
       if (newPos.dy >= paddleY &&
-          (newPos.dx - paddleX).abs() <= paddleHalfWidth) {
+          (newPos.dx - paddleX).abs() <= GameDimensions.paddleHalfWidth) {
         powerUps.removeAt(i);
         _activatePowerUp(p.type);
         continue;
@@ -341,10 +386,10 @@ class GameViewModel extends ChangeNotifier {
       final newPos = projectiles[i].translate(0, -projectileSpeed);
       bool remove = false;
       final projRect = Rect.fromLTWH(
-        newPos.dx - projectileWidth / 2,
-        newPos.dy - projectileHeight / 2,
-        projectileWidth,
-        projectileHeight,
+        newPos.dx - GameDimensions.projectileWidth / 2,
+        newPos.dy - GameDimensions.projectileHeight / 2,
+        GameDimensions.projectileWidth,
+        GameDimensions.projectileHeight,
       );
 
       for (int j = 0; j < blocks.length; j++) {
@@ -379,8 +424,8 @@ class GameViewModel extends ChangeNotifier {
     }
 
     // 🧱 Unten raus
-    if (ball.position.dy >= 1.0) {
-      ball.position = Offset(ball.position.dx, 1.0);
+    ballManager.removeOffscreen();
+    if (ballManager.isEmpty) {
       _gameOver();
     }
 
@@ -394,34 +439,56 @@ class GameViewModel extends ChangeNotifier {
   }
 
   void _activatePowerUp(PowerUpType type) {
+    if (type == PowerUpType.multiball) {
+      _spawnMultiballs();
+      return;
+    }
+
     activePowerUps.add(type);
     _timers[type]?.cancel();
-    _timers[type] = Timer(powerUpDuration, () {
-      activePowerUps.remove(type);
-      if (type == PowerUpType.fireball && ball is Fireball) {
-        ball = (ball as Fireball).ball;
-        ballCollisionStrategy = DefaultBounceStrategy();
-      }
-      if (type == PowerUpType.phaseball) {
-        ballCollisionStrategy = DefaultBounceStrategy();
-      }
-      if (type == PowerUpType.gun) {
-        _gunFireTimer?.cancel();
-        _gunFireTimer = null;
-      }
-      notifyListeners();
-    });
+    final duration =
+        type == PowerUpType.magnet ? magnetHoldDuration : powerUpDuration;
+    _timers[type] = Timer(duration, () => _deactivatePowerUp(type));
+
+    if (type == PowerUpType.magnet) {
+      _magnetActive = true;
+    }
     if (type == PowerUpType.gun) {
+      _gunShotsRemaining = maxGunShots;
       _gunFireTimer?.cancel();
-      _gunFireTimer = Timer.periodic(gunFireInterval, (_) => _fireProjectile());
+      _gunFireTimer =
+          Timer.periodic(gunFireInterval, (_) => _fireProjectile());
     }
     if (type == PowerUpType.fireball) {
-      ball = Fireball(ball);
       ballCollisionStrategy = FireballCollisionStrategy();
     }
     if (type == PowerUpType.phaseball) {
       ballCollisionStrategy = PhaseballCollisionStrategy();
     }
+    notifyListeners();
+  }
+
+  void _deactivatePowerUp(PowerUpType type) {
+    activePowerUps.remove(type);
+    _timers[type]?.cancel();
+    if (type == PowerUpType.magnet) {
+      _magnetActive = false;
+      if (balls.isNotEmpty) {
+        balls.first.velocity = const Offset(0, -minBallSpeed);
+      }
+    }
+    if (type == PowerUpType.fireball) {
+      ballCollisionStrategy = DefaultBounceStrategy();
+    }
+    if (type == PowerUpType.phaseball) {
+      ballCollisionStrategy = DefaultBounceStrategy();
+    }
+    if (type == PowerUpType.gun) {
+      _gunFireTimer?.cancel();
+      _gunFireTimer = null;
+      _gunShotsRemaining = 0;
+    }
+    _timers.remove(type);
     notifyListeners();
   }
 
@@ -435,8 +502,38 @@ class GameViewModel extends ChangeNotifier {
     return DefaultBounceStrategy();
   }
 
+  /// Spawns additional balls when the multiball power-up is collected.
+  void _spawnMultiballs() {
+    if (balls.isEmpty) return;
+    final base = balls.first;
+    const spreads = [
+      Offset(-0.01, -0.02),
+      Offset(0.01, -0.02),
+      Offset(-0.02, -0.01),
+      Offset(0.02, -0.01),
+    ];
+    for (final offset in spreads) {
+      final newBall = Ball(position: base.position, velocity: base.velocity + offset);
+      ballManager.addBall(newBall);
+    }
+    notifyListeners();
+  }
+
   void _fireProjectile() {
-    projectiles.add(const Offset(paddleInitialX, projectileStartY));
+    if (_gunShotsRemaining <= 0) {
+      _deactivatePowerUp(PowerUpType.gun);
+      return;
+    }
+
+    final startY = paddleY -
+        GameDimensions.paddleHeight / 2 -
+        GameDimensions.projectileHeight / 2;
+    final leftX = paddleX - GameDimensions.paddleHalfWidth;
+    final rightX = paddleX + GameDimensions.paddleHalfWidth;
+
+    projectiles.add(Offset(leftX, startY));
+    projectiles.add(Offset(rightX, startY));
+    _gunShotsRemaining--;
     notifyListeners();
   }
 }


### PR DESCRIPTION
## Summary
- document magnet power-up and how it temporarily overrides collision strategies
- add magnet hold duration constant
- implement magnet power-up logic in `GameViewModel`
- **new:** composite BallManager and multiball support

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a921f15648325830faa2564d30149