### PR TITLE
Add secure Spring Boot API for CI security testing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "image": "ghcr.io/devcontainers/java:1-21@sha256:5cc2b8b4e9ac898b1c881c34e65e073cfcd49007f4618c7f63c19e78146ee366",
+  "customizations": {
+    "vscode": {
+      "extensions": ["vscjava.vscode-java-pack"]
+    }
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{java,kt,kts,xml,yml,yaml}]
+indent_style = space
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - uses: gradle/actions/setup-gradle@v3
+      - run: make qualityAll
+      - run: make securityAll

--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,12 @@ unlinked_spec.ds
 # Coverage
 coverage/
 
+# Java
+*.jar
+*.war
+build/
+.jqwik-database/
+
 # Symbols
 app.*.symbols
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-added-large-files

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# use readOnlyRootFilesystem and no-new-privileges at runtime
+FROM eclipse-temurin:21-jre@sha256:3f1b3df0f22a1e8be7cd7e5d9b5c9f3f3f94a639a6a39aea66e68132c0aaf645
+
+WORKDIR /app
+RUN adduser --system --group app
+USER app
+
+COPY build/libs/security-api-0.0.1-SNAPSHOT.jar app.jar
+
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: securityAll qualityAll
+
+securityAll:
+	gradle dependencyCheckAnalyze cyclonedxBom spotbugsMain checkstyleMain pmdMain pitest
+
+qualityAll:
+	gradle clean test jacocoTestReport

--- a/README.md
+++ b/README.md
@@ -45,3 +45,34 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Security Testing API
+
+This repository also contains a small Spring Boot 3 REST API intended for security tooling demonstrations.
+
+### Run
+
+```bash
+gradle bootRun
+```
+
+### Login and use
+
+```bash
+curl -X POST -H 'Content-Type: application/json' \
+  -d '{"username":"user","password":"password"}' http://localhost:8080/api/auth/login
+```
+
+Use the returned JWT to access protected routes:
+
+```bash
+curl -H 'Authorization: Bearer <token>' http://localhost:8080/api/users/me
+```
+
+Admin endpoint:
+
+```bash
+curl -X POST -H 'Authorization: Bearer <admin-token>' http://localhost:8080/api/admin/stats
+```
+
+Security features include rate limiting, strict headers, validation and centralized error handling. See `docs/SECURITY.md` for threat modeling notes.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,85 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
+plugins {
+    id("java")
+    id("org.springframework.boot") version "3.2.5"
+    id("io.spring.dependency-management") version "1.1.4"
+    id("jacoco")
+    id("checkstyle")
+    id("pmd")
+    id("com.github.spotbugs") version "6.0.4"
+    id("info.solidsoft.pitest") version "1.15.0"
+    id("org.owasp.dependencycheck") version "9.0.9"
+    id("org.cyclonedx.bom") version "1.7.4"
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web:3.2.5")
+    implementation("org.springframework.boot:spring-boot-starter-validation:3.2.5")
+    implementation("org.springframework.boot:spring-boot-starter-security:3.2.5")
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+    implementation("org.springframework.security:spring-security-crypto:6.2.3")
+    implementation("com.github.vladimir-bukhtoyarov:bucket4j-core:8.0.1")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test:3.2.5")
+    testImplementation("io.rest-assured:rest-assured:5.4.0")
+    testImplementation("net.jqwik:jqwik:1.8.2")
+}
+
+configurations.all {
+    resolutionStrategy.cacheChangingModulesFor(0, "seconds")
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}
+
+spotbugs {
+    effort.set(com.github.spotbugs.snom.Effort.MAX)
+    reportLevel.set(com.github.spotbugs.snom.Confidence.LOW)
+}
+
+pitest {
+    junit5PluginVersion.set("1.2.1")
+}
+
+checkstyle {
+    toolVersion = "10.17.0"
+}
+
+pmd {
+    toolVersion = "6.55.0"
+}
+
+tasks.withType<JavaCompile> {
+    options.encoding = "UTF-8"
+}
+

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Notes
+
+## STRIDE Analysis
+
+### /api/echo
+- **Spoofing**: Auth not required but input sanitized.
+- **Tampering**: Read-only; validated query parameter.
+- **Repudiation**: Requests logged with correlation ID.
+- **Information Disclosure**: Output encoded to prevent XSS.
+- **Denial of Service**: Rate limited per IP.
+- **Elevation of Privilege**: No auth context.
+
+### /api/users/{id}
+- **Spoofing**: JWT-based auth, user ID verified against token to prevent IDOR.
+- **Tampering**: Read-only, no modifications allowed.
+- **Repudiation**: Correlation ID logged.
+- **Information Disclosure**: Only own profile returned.
+- **Denial of Service**: Rate limited.
+- **Elevation of Privilege**: Role checks enforced.
+
+### /api/admin/stats
+- **Spoofing**: JWT with ROLE_ADMIN required.
+- **Tampering**: Admin-only, no external input.
+- **Repudiation**: Correlation ID logged.
+- **Information Disclosure**: Exposes aggregate info only.
+- **Denial of Service**: Rate limited.
+- **Elevation of Privilege**: Strict role checks.
+
+Tests covering these endpoints are located under `src/test/java`.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.configuration-cache=true
+org.gradle.caching=true
+org.gradle.parallel=true
+javaVersion=21

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,78 @@
+openapi: 3.0.1
+info:
+  title: Security API
+  version: 0.0.1
+servers:
+  - url: http://localhost:8080
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+paths:
+  /api/health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: OK
+  /api/auth/login:
+    post:
+      summary: Login
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '200':
+          description: JWT token
+  /api/echo:
+    get:
+      summary: Echo input
+      parameters:
+        - in: query
+          name: q
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Sanitized echo
+  /api/users/me:
+    get:
+      security:
+        - bearerAuth: []
+      summary: Current user
+      responses:
+        '200':
+          description: User info
+  /api/users/{id}:
+    get:
+      security:
+        - bearerAuth: []
+      summary: User by id
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+      responses:
+        '200':
+          description: User info
+        '403':
+          description: Forbidden
+  /api/admin/stats:
+    post:
+      security:
+        - bearerAuth: []
+      summary: Admin stats
+      responses:
+        '200':
+          description: Stats info

--- a/policy/conftest/policy.rego
+++ b/policy/conftest/policy.rego
@@ -1,0 +1,26 @@
+package main
+
+deny[msg] {
+  input.image.tag == "latest"
+  msg := "images must not use latest tag"
+}
+
+deny[msg] {
+  not input.image.digest
+  msg := "image digest must be pinned"
+}
+
+deny[msg] {
+  input.container.runAsRoot == true
+  msg := "containers must not run as root"
+}
+
+deny[msg] {
+  input.container.securityContext.readOnlyRootFilesystem != true
+  msg := "readOnlyRootFilesystem must be true"
+}
+
+deny[msg] {
+  input.container.securityContext.allowPrivilegeEscalation == true
+  msg := "no-new-privileges required"
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "security-api"

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -1,0 +1,11 @@
+package com.example.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/demo/controller/AdminController.java
+++ b/src/main/java/com/example/demo/controller/AdminController.java
@@ -1,0 +1,23 @@
+package com.example.demo.controller;
+
+import com.example.demo.repo.UserRepository;
+import java.util.Map;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/admin", produces = MediaType.APPLICATION_JSON_VALUE)
+public class AdminController {
+    private final UserRepository userRepository;
+
+    public AdminController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @PostMapping("/stats")
+    public Map<String, Long> stats() {
+        return Map.of("users", userRepository.count());
+    }
+}

--- a/src/main/java/com/example/demo/controller/AuthController.java
+++ b/src/main/java/com/example/demo/controller/AuthController.java
@@ -1,0 +1,36 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.LoginRequest;
+import com.example.demo.model.LoginResponse;
+import com.example.demo.repo.UserRepository;
+import com.example.demo.security.JwtService;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/auth", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+public class AuthController {
+    private final UserRepository userRepository;
+    private final PasswordEncoder encoder;
+    private final JwtService jwtService;
+
+    public AuthController(UserRepository userRepository, PasswordEncoder encoder, JwtService jwtService) {
+        this.userRepository = userRepository;
+        this.encoder = encoder;
+        this.jwtService = jwtService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        return userRepository.findByUsername(request.getUsername())
+                .filter(u -> encoder.matches(request.getPassword(), u.password()))
+                .map(u -> ResponseEntity.ok(new LoginResponse(jwtService.generateToken(u.id(), u.roles()))))
+                .orElse(ResponseEntity.status(401).build());
+    }
+}

--- a/src/main/java/com/example/demo/controller/EchoController.java
+++ b/src/main/java/com/example/demo/controller/EchoController.java
@@ -1,0 +1,19 @@
+package com.example.demo.controller;
+
+import jakarta.validation.constraints.Size;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.HtmlUtils;
+import java.util.Map;
+
+@RestController
+@RequestMapping(value = "/api", produces = MediaType.APPLICATION_JSON_VALUE)
+public class EchoController {
+    @GetMapping("/echo")
+    public Map<String, String> echo(@RequestParam("q") @Size(max = 100) String q) {
+        return Map.of("echo", HtmlUtils.htmlEscape(q));
+    }
+}

--- a/src/main/java/com/example/demo/controller/HealthController.java
+++ b/src/main/java/com/example/demo/controller/HealthController.java
@@ -1,0 +1,15 @@
+package com.example.demo.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class HealthController {
+    @GetMapping("/health")
+    public ResponseEntity<String> health() {
+        return ResponseEntity.ok("OK");
+    }
+}

--- a/src/main/java/com/example/demo/controller/UserController.java
+++ b/src/main/java/com/example/demo/controller/UserController.java
@@ -1,0 +1,38 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.User;
+import com.example.demo.repo.UserRepository;
+import java.security.Principal;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/users", produces = MediaType.APPLICATION_JSON_VALUE)
+public class UserController {
+    private final UserRepository userRepository;
+
+    public UserController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<User> me(Principal principal) {
+        return userRepository.findById(principal.getName())
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<User> byId(@PathVariable String id, Principal principal) {
+        if (!principal.getName().equals(id)) {
+            return ResponseEntity.status(403).build();
+        }
+        return userRepository.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/example/demo/exception/ApiError.java
+++ b/src/main/java/com/example/demo/exception/ApiError.java
@@ -1,0 +1,5 @@
+package com.example.demo.exception;
+
+import java.time.Instant;
+
+public record ApiError(Instant timestamp, String path, int code, String message, String correlationId) {}

--- a/src/main/java/com/example/demo/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/exception/GlobalExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.example.demo.exception;
+
+import com.example.demo.security.CorrelationIdFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Instant;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        String msg = ex.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(e -> e.getField() + " " + e.getDefaultMessage())
+                .orElse("Validation error");
+        return errorResponse(request, HttpStatus.BAD_REQUEST, msg);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiError> handleAccessDenied(AccessDeniedException ex, HttpServletRequest request) {
+        return errorResponse(request, HttpStatus.FORBIDDEN, "Forbidden");
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiError> handleOther(Exception ex, HttpServletRequest request) {
+        return errorResponse(request, HttpStatus.INTERNAL_SERVER_ERROR, "Unexpected error");
+    }
+
+    private ResponseEntity<ApiError> errorResponse(HttpServletRequest req, HttpStatus status, String msg) {
+        ApiError error = new ApiError(Instant.now(), req.getRequestURI(), status.value(), msg,
+                req.getHeader(CorrelationIdFilter.CORRELATION_ID));
+        return ResponseEntity.status(status).body(error);
+    }
+}

--- a/src/main/java/com/example/demo/model/LoginRequest.java
+++ b/src/main/java/com/example/demo/model/LoginRequest.java
@@ -1,0 +1,26 @@
+package com.example.demo.model;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+    @NotBlank
+    private String username;
+    @NotBlank
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/example/demo/model/LoginResponse.java
+++ b/src/main/java/com/example/demo/model/LoginResponse.java
@@ -1,0 +1,3 @@
+package com.example.demo.model;
+
+public record LoginResponse(String token) {}

--- a/src/main/java/com/example/demo/model/User.java
+++ b/src/main/java/com/example/demo/model/User.java
@@ -1,0 +1,5 @@
+package com.example.demo.model;
+
+import java.util.Set;
+
+public record User(String id, String username, String password, Set<String> roles) {}

--- a/src/main/java/com/example/demo/repo/UserRepository.java
+++ b/src/main/java/com/example/demo/repo/UserRepository.java
@@ -1,0 +1,31 @@
+package com.example.demo.repo;
+
+import com.example.demo.model.User;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class UserRepository {
+    private final Map<String, User> users = new ConcurrentHashMap<>();
+
+    public UserRepository(PasswordEncoder encoder) {
+        users.put("1", new User("1", "user", encoder.encode("password"), Set.of("ROLE_USER")));
+        users.put("2", new User("2", "admin", encoder.encode("password"), Set.of("ROLE_ADMIN")));
+    }
+
+    public Optional<User> findByUsername(String username) {
+        return users.values().stream().filter(u -> u.username().equals(username)).findFirst();
+    }
+
+    public Optional<User> findById(String id) {
+        return Optional.ofNullable(users.get(id));
+    }
+
+    public long count() {
+        return users.size();
+    }
+}

--- a/src/main/java/com/example/demo/security/CorrelationIdFilter.java
+++ b/src/main/java/com/example/demo/security/CorrelationIdFilter.java
@@ -1,0 +1,32 @@
+package com.example.demo.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class CorrelationIdFilter extends OncePerRequestFilter {
+    public static final String CORRELATION_ID = "X-Correlation-Id";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String id = request.getHeader(CORRELATION_ID);
+        if (id == null || id.isBlank()) {
+            id = UUID.randomUUID().toString();
+        }
+        MDC.put(CORRELATION_ID, id);
+        response.setHeader(CORRELATION_ID, id);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(CORRELATION_ID);
+        }
+    }
+}

--- a/src/main/java/com/example/demo/security/JwtAuthFilter.java
+++ b/src/main/java/com/example/demo/security/JwtAuthFilter.java
@@ -1,0 +1,41 @@
+package com.example.demo.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Set;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthFilter extends OncePerRequestFilter {
+    private final JwtService jwtService;
+    public JwtAuthFilter(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+        if (StringUtils.hasText(header) && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            try {
+                String userId = jwtService.validateAndGetUserId(token);
+                Set<String> roles = jwtService.extractRoles(token);
+                var authorities = roles.stream().map(SimpleGrantedAuthority::new).toList();
+                var auth = new UsernamePasswordAuthenticationToken(userId, token, authorities);
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            } catch (Exception e) {
+                // ignore invalid token
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/demo/security/JwtService.java
+++ b/src/main/java/com/example/demo/security/JwtService.java
@@ -1,0 +1,53 @@
+package com.example.demo.security;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtService {
+    private final Key key;
+    private final long expiration;
+
+    public JwtService(@Value("${app.jwt.secret}") String secret,
+                      @Value("${app.jwt.expiration}") long expiration) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expiration = expiration;
+    }
+
+    public String generateToken(String userId, Set<String> roles) {
+        long now = System.currentTimeMillis();
+        return Jwts.builder()
+                .setSubject(userId)
+                .claim("roles", String.join(",", roles))
+                .setIssuedAt(new Date(now))
+                .setExpiration(new Date(now + expiration))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String validateAndGetUserId(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public Set<String> extractRoles(String token) {
+        String roles = (String) Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("roles");
+        return Set.of(roles.split(","));
+    }
+}

--- a/src/main/java/com/example/demo/security/RateLimitFilter.java
+++ b/src/main/java/com/example/demo/security/RateLimitFilter.java
@@ -1,0 +1,35 @@
+package com.example.demo.security;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+    private final Map<String, Bucket> cache = new ConcurrentHashMap<>();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String key = request.getRemoteAddr() + ":" + request.getRequestURI();
+        Bucket bucket = cache.computeIfAbsent(key, k -> Bucket.builder()
+                .addLimit(Bandwidth.classic(10, Refill.greedy(10, Duration.ofMinutes(1))))
+                .build());
+        if (bucket.tryConsume(1)) {
+            filterChain.doFilter(request, response);
+        } else {
+            response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+        }
+    }
+}

--- a/src/main/java/com/example/demo/security/SecurityConfig.java
+++ b/src/main/java/com/example/demo/security/SecurityConfig.java
@@ -1,0 +1,76 @@
+package com.example.demo.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class SecurityConfig {
+    private final JwtAuthFilter jwtAuthFilter;
+    private final RateLimitFilter rateLimitFilter;
+    private final CorrelationIdFilter correlationIdFilter;
+    private final String allowedOrigins;
+
+    public SecurityConfig(JwtAuthFilter jwtAuthFilter, RateLimitFilter rateLimitFilter,
+                          CorrelationIdFilter correlationIdFilter,
+                          @Value("${app.cors.allowed-origins}") String allowedOrigins) {
+        this.jwtAuthFilter = jwtAuthFilter;
+        this.rateLimitFilter = rateLimitFilter;
+        this.correlationIdFilter = correlationIdFilter;
+        this.allowedOrigins = allowedOrigins;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .cors(Customizer.withDefaults())
+            .headers(headers -> {
+                headers.httpStrictTransportSecurity(hsts -> hsts.includeSubDomains(true).preload(true));
+                headers.contentTypeOptions(Customizer.withDefaults());
+                headers.frameOptions(frame -> frame.deny());
+                headers.referrerPolicy(rp -> rp.policy(org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy.NO_REFERRER));
+                headers.permissionsPolicy(pp -> pp.policy("geolocation=(), microphone=()"));
+                headers.contentSecurityPolicy(csp -> csp.policyDirectives("default-src 'self'"));
+            })
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(HttpMethod.TRACE, "/**").denyAll()
+                .requestMatchers(HttpMethod.GET, "/api/health").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/echo").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/admin/**").hasRole("ADMIN")
+                .anyRequest().authenticated())
+            .addFilterBefore(correlationIdFilter, UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(rateLimitFilter, CorrelationIdFilter.class)
+            .addFilterBefore(jwtAuthFilter, RateLimitFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(java.util.List.of(allowedOrigins));
+        config.setAllowedMethods(java.util.List.of("GET", "POST"));
+        config.setAllowedHeaders(java.util.List.of("Authorization", "Content-Type"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+server:
+  error:
+    include-stacktrace: never
+  tomcat:
+    max-http-form-post-size: 1024
+spring:
+  mvc:
+    dispatch-options-request: true
+  web:
+    resources:
+      add-mappings: false
+app:
+  jwt:
+    secret: 0123456789abcdef0123456789abcdef
+    expiration: 600000
+  cors:
+    allowed-origins: https://example.com

--- a/src/test/java/com/example/demo/ApiTest.java
+++ b/src/test/java/com/example/demo/ApiTest.java
@@ -1,0 +1,64 @@
+package com.example.demo;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import org.junit.jupiter.api.Assertions;
+import org.springframework.web.util.HtmlUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ApiTest {
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setup() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    void health() {
+        given().when().get("/api/health").then().statusCode(200).body(equalTo("OK"));
+    }
+
+    @Test
+    void loginAndAccess() {
+        String token = login("user", "password");
+        given().header("Authorization", "Bearer " + token)
+                .when().get("/api/users/me").then().statusCode(200)
+                .body("username", equalTo("user"));
+        given().header("Authorization", "Bearer " + token)
+                .when().get("/api/users/2").then().statusCode(403);
+    }
+
+    @Test
+    void adminAccess() {
+        String token = login("admin", "password");
+        given().header("Authorization", "Bearer " + token)
+                .contentType(ContentType.JSON)
+                .when().post("/api/admin/stats").then().statusCode(200)
+                .body("users", equalTo(2));
+    }
+
+    private String login(String user, String pass) {
+        return given().contentType(ContentType.JSON)
+                .body("{\"username\":\"" + user + "\",\"password\":\"" + pass + "\"}")
+                .when().post("/api/auth/login")
+                .then().statusCode(200)
+                .extract().path("token");
+    }
+
+    @Property
+    void echoIsSanitized(@ForAll String input) {
+        String escaped = HtmlUtils.htmlEscape(input);
+        Assertions.assertFalse(escaped.contains("<"));
+    }
+}

--- a/zap/context.yaml
+++ b/zap/context.yaml
@@ -1,0 +1,4 @@
+context:
+  name: security-api
+  includePaths:
+    - http://localhost:8080/.*

--- a/zap/login.js
+++ b/zap/login.js
@@ -1,0 +1,13 @@
+function authenticate(helper, paramsValues, credentials) {
+    var data = JSON.stringify({
+        username: credentials.getParam('username'),
+        password: credentials.getParam('password')
+    });
+    var msg = helper.prepareMessage();
+    msg.setRequestHeader("POST " + paramsValues.get('loginUrl') + " HTTP/1.1");
+    msg.getRequestHeader().setHeader('Content-Type', 'application/json');
+    msg.setRequestBody(data);
+    helper.sendAndReceive(msg);
+    var token = JSON.parse(msg.getResponseBody().toString()).token;
+    return token;
+}


### PR DESCRIPTION
## Summary
- add Java 21 Spring Boot API with JWT auth, rate limiting and validation
- document security model and provide OpenAPI spec
- wire up CI with Gradle tasks, Dockerfile, OPA policies and ZAP scripts

## Testing
- `gradle test`
- `gradle jacocoTestReport`
- `gradle dependencyCheckAnalyze` *(fails: Error updating the NVD Data; the NVD returned a 403 or 404 error)*
- `gradle cyclonedxBom` *(fails: The BOM does not conform to the CycloneDX BOM standard)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb3cdb0488325958a8a49b3d1c5ab